### PR TITLE
Fixing a typo

### DIFF
--- a/src/Listener/ConnectionListener.cs
+++ b/src/Listener/ConnectionListener.cs
@@ -168,7 +168,7 @@ namespace Amqp.Listener
         {
             if (this.saslSettings != null)
             {
-                ListenerSasProfile profile = new ListenerSasProfile(this);
+                ListenerSaslProfile profile = new ListenerSaslProfile(this);
                 transport = await profile.OpenAsync(null, transport);
             }
 
@@ -306,12 +306,12 @@ namespace Amqp.Listener
             }
         }
 
-        class ListenerSasProfile : SaslProfile
+        class ListenerSaslProfile : SaslProfile
         {
             readonly ConnectionListener listener;
             SaslProfile innerProfile;
 
-            public ListenerSasProfile(ConnectionListener listener)
+            public ListenerSaslProfile(ConnectionListener listener)
             {
                 this.listener = listener;
             }

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -49,9 +49,9 @@ namespace Amqp
         /// </summary>
         /// <param name="session">The session within which to create the link.</param>
         /// <param name="name">The link name.</param>
-        /// <param name="adderss">The node address.</param>
-        public SenderLink(Session session, string name, string adderss)
-            : this(session, name, new Target() { Address = adderss }, null)
+        /// <param name="address">The node address.</param>
+        public SenderLink(Session session, string name, string address)
+            : this(session, name, new Target() { Address = address }, null)
         {
         }
 


### PR DESCRIPTION
Fixing a typo in ListenerSasProfile class name. "Sas" was missing the l in "Sasl". 