### PR TITLE
Fixing typos

### DIFF
--- a/Examples/Listener/Listener.ContainerHost/Program.cs
+++ b/Examples/Listener/Listener.ContainerHost/Program.cs
@@ -46,7 +46,7 @@ namespace Listener.ContainerHost
             host.RegisterLinkProcessor(new LinkProcessor());
             Console.WriteLine("Link processor is registered");
 
-            Console.WriteLine("Press enter key to exist...");
+            Console.WriteLine("Press enter key to exit...");
             Console.ReadLine();
 
             host.Close();

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -49,9 +49,9 @@ namespace Amqp
         /// </summary>
         /// <param name="session">The session within which to create the link.</param>
         /// <param name="name">The link name.</param>
-        /// <param name="adderss">The node address.</param>
-        public SenderLink(Session session, string name, string adderss)
-            : this(session, name, new Target() { Address = adderss }, null)
+        /// <param name="address">The node address.</param>
+        public SenderLink(Session session, string name, string address)
+            : this(session, name, new Target() { Address = address }, null)
         {
         }
 


### PR DESCRIPTION
Fixing a typo in the SenderLink constructor - "adderss" should be "address"
Fixing a typo in an example - "exist" should be "exit"