### PR TITLE
Removes all processors when the container host is closed

### DIFF
--- a/src/Listener/ContainerHost.cs
+++ b/src/Listener/ContainerHost.cs
@@ -86,7 +86,11 @@ namespace Amqp.Listener
         /// <summary>
         /// Closes the container host object.
         /// </summary>
-        public void Close()
+        /// <param name="removeProcessors">
+        /// If true this will remove all message and request processors associated with the container.
+        /// This will detach all links associated with the processors.
+        /// </param>
+        public void Close(bool removeProcessors = false)
         {
             foreach (var listener in this.listeners)
             {
@@ -98,6 +102,12 @@ namespace Amqp.Listener
                 {
                     Trace.WriteLine(TraceLevel.Error, exception.ToString());
                 }
+            }
+
+            if (removeProcessors)
+            {
+                RemoveAllProcessors(this.messageProcessors);
+                RemoveAllProcessors(this.requestProcessors);
             }
         }
 
@@ -184,6 +194,17 @@ namespace Amqp.Listener
                     {
                         ((IDisposable)processor).Dispose();
                     }
+                }
+            }
+        }
+
+        static void RemoveAllProcessors<T>(Dictionary<string, T> processors)
+        {
+            lock (processors)
+            {
+                foreach (var key in new List<string>(processors.Keys))
+                {
+                    RemoveProcessor(processors, key);
                 }
             }
         }

--- a/src/Listener/ContainerHost.cs
+++ b/src/Listener/ContainerHost.cs
@@ -134,9 +134,9 @@ namespace Amqp.Listener
         /// </summary>
         /// <param name="address">The node name.</param>
         /// <param name="messageProcessor">The message processor.</param>
-        public void RegisterMessageProcessor(string address, IMessageProcessor messageProcessor, Action<Link> onLinkAttached = null)
+        public void RegisterMessageProcessor(string address, IMessageProcessor messageProcessor)
         {
-            AddProcessor(this.messageProcessors, address, new MessageProcessor(messageProcessor, onLinkAttached));
+            AddProcessor(this.messageProcessors, address, new MessageProcessor(messageProcessor));
         }
 
         /// <summary>
@@ -265,13 +265,11 @@ namespace Amqp.Listener
             static readonly Action<ListenerLink, Message, DeliveryState, object> dispatchMessage = DispatchMessage;
             readonly IMessageProcessor processor;
             readonly List<ListenerLink> links;
-            readonly Action<Link> onLinkAttached;
 
-            public MessageProcessor(IMessageProcessor processor, Action<Link> onLinkAttached)
+            public MessageProcessor(IMessageProcessor processor)
             {
                 this.processor = processor;
                 this.links = new List<ListenerLink>();
-                this.onLinkAttached = onLinkAttached;
             }
 
             public void AddLink(ListenerLink link, string address)
@@ -286,11 +284,6 @@ namespace Amqp.Listener
                 lock (this.links)
                 {
                     this.links.Add(link);
-
-                    if (onLinkAttached != null)
-                    {
-                        onLinkAttached(link);
-                    }
                 }
             }
 


### PR DESCRIPTION
This is related to issue https://github.com/Azure/amqpnetlite/issues/10.

When the container host is closed existing links can still send data. In our use case we wan't to cease all inbound data. Amqp.Net lite already provides a mechanism to do this by disposing of processors and therefore detaching all existing links. This extends this functionality to occur on a close. Our only alternative would be to keep track of all processor keys that we have created and manually remove them. 

On a side note it would be very helpful to be more specific about testing requirements in the contribution wiki. The testing for the library appears to be limited so far. I would like to add unit tests to Test.Amqp.Net to test this ContainerHost functionality. I would also like to add a reference to the Moq NuGet package for the test to mock out IRequestProcessor and IMessageProcessor. Would this be acceptable? 
