### PR TITLE
Throw an argument exception if the message to send is empty

### DIFF
--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -141,10 +141,16 @@ namespace Amqp
 
         internal void Send(Message message, DeliveryState deliveryState, OutcomeCallback callback, object state)
         {
+            var buffer = message.Encode();
+            if (buffer.Length < 1)
+            {
+                throw new ArgumentException("Cannot send an empty message.");
+            }
+
             Delivery delivery = new Delivery()
             {
                 Message = message,
-                Buffer = message.Encode(),
+                Buffer = buffer,
                 State = deliveryState,
                 Link = this,
                 OnOutcome = callback,

--- a/test/Test.Amqp.NetMF/LinkTests.cs
+++ b/test/Test.Amqp.NetMF/LinkTests.cs
@@ -655,7 +655,9 @@ namespace Test.Amqp
         /// This test proves that issue #14 is fixed.
         /// https://github.com/Azure/amqpnetlite/issues/14
         /// </summary>
+#if !(NETMF || COMPACT_FRAMEWORK)
         [TestMethod]
+#endif
         public void TestMethod_SendEmptyMessage()
         {
             string testName = "SendEmptyMessage";

--- a/test/Test.Amqp.NetMF/LinkTests.cs
+++ b/test/Test.Amqp.NetMF/LinkTests.cs
@@ -650,5 +650,37 @@ namespace Test.Amqp
             session.Close();
             connection.Close();
         }
+
+        /// <summary>
+        /// This test proves that issue #14 is fixed.
+        /// https://github.com/Azure/amqpnetlite/issues/14
+        /// </summary>
+        [TestMethod]
+        public void TestMethod_SendEmptyMessage()
+        {
+            string testName = "SendEmptyMessage";
+
+            Connection connection = new Connection(address);
+            Session session = new Session(connection);
+            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+
+            bool threwArgEx = false;
+            try
+            {
+                sender.Send(new Message());
+            }
+            catch (ArgumentException)
+            {
+                threwArgEx = true;
+            }
+            finally
+            {
+                sender.Close();
+                session.Close();
+                connection.Close();
+            }
+
+            Assert.IsTrue(threwArgEx, "Should throw an argument exception when sending an empty message.");
+        }
     }
 }


### PR DESCRIPTION
This is a fix for issue https://github.com/Azure/amqpnetlite/issues/14.

In SenderLink it checks to see if the message is empty before constructing the delivery object. If the message is empty then an ArgumentException is thrown.