### PR TITLE
fix(Serialization): enable serialization for Amqp.Net35

### DIFF
--- a/src/Amqp.Net35.csproj
+++ b/src/Amqp.Net35.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DOTNET35</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;DOTNET35</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Framing/AmqpValue.cs
+++ b/src/Framing/AmqpValue.cs
@@ -43,7 +43,7 @@ namespace Amqp.Framing
             set { this.value = value; }
         }
 
-#if DOTNET
+#if (DOTNET || DOTNET35)
         ByteBuffer valueBuffer;
 
         internal T GetValue<T>()


### PR DESCRIPTION
Previously, the AmqpSerializer would only be enabled for projects
defining "DOTNET". The Amqp.Net35 project can't enable this
wholesale (as there are other non-related differences it seems),
but allowing for a separate DOTNET35 define seems to enable this
behavior again in Amqp.Net35