### PR TITLE
feat(OnSerialized): add support for specifying OnSerialized

### DIFF
--- a/src/Serialization/AmqpSerializer.cs
+++ b/src/Serialization/AmqpSerializer.cs
@@ -204,6 +204,7 @@ namespace Amqp.Serialization
             int lastOrder = memberList.Count + 1;
             MemberInfo[] memberInfos = type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             MethodAccessor onDeserialized = null;
+            MethodAccessor onSerialized = null;
             foreach (MemberInfo memberInfo in memberInfos)
             {
                 if (memberInfo.DeclaringType != type)
@@ -239,6 +240,12 @@ namespace Amqp.Serialization
                     if (memberAttributes.Length == 1)
                     {
                         onDeserialized = MethodAccessor.Create((MethodInfo)memberInfo);
+                    }
+
+                    memberAttributes = memberInfo.GetCustomAttributes(typeof(OnSerializedAttribute), false);
+                    if (memberAttributes.Length == 1)
+                    {
+                        onSerialized = MethodAccessor.Create((MethodInfo)memberInfo);
                     }
                 }
             }
@@ -279,12 +286,12 @@ namespace Amqp.Serialization
             if (contractAttribute.Encoding == EncodingType.List)
             {
                 return SerializableType.CreateDescribedListType(this, type, baseType, descriptorName, 
-                    descriptorCode, members, knownTypes, onDeserialized);
+                    descriptorCode, members, knownTypes, onDeserialized, onSerialized);
             }
             else if (contractAttribute.Encoding == EncodingType.Map)
             {
                 return SerializableType.CreateDescribedMapType(this, type, baseType, descriptorName,
-                    descriptorCode, members, knownTypes, onDeserialized);
+                    descriptorCode, members, knownTypes, onDeserialized, onSerialized);
             }
             else
             {

--- a/test/Test.Amqp.Net/AmqpCodecTests.cs
+++ b/test/Test.Amqp.Net/AmqpCodecTests.cs
@@ -533,6 +533,18 @@ namespace Test.Amqp
         }
 
         [TestMethod()]
+        public void AmqpSerializerOnSerializedTest()
+        {
+            var person = new PersonWithOnSerialized("Methuselah") { Age = 99 };
+            var buffer = new ByteBuffer(1024, true);
+            AmqpSerializer.Serialize(buffer, person);
+
+            var person2 = AmqpSerializer.Deserialize<PersonWithOnSerialized>(buffer);
+            Assert.AreEqual(person.Name, person2.Name);
+            Assert.Equals(person2.Age, 42);
+        }
+
+        [TestMethod()]
         public void AmqpSerializerMapEncodingTest()
         {
             var product = new Product() { Name = "Computer", Price = 499.98, Weight = 30 };

--- a/test/Test.Amqp.Net/Person.cs
+++ b/test/Test.Amqp.Net/Person.cs
@@ -73,6 +73,27 @@ namespace Test.Amqp
         }
     }
 
+    [AmqpContract(Name = "test.amqp:person", Code = 0x0000123400000000)]
+    class PersonWithOnSerialized
+    {
+        public PersonWithOnSerialized(string name)
+        {
+            this.Name = name;
+        }
+
+        [AmqpMember(Order = 1)]
+        public string Name { get; private set; }
+
+        [AmqpMember(Order = 2)]
+        public int Age { get; set; }
+
+        [System.Runtime.Serialization.OnSerialized]
+        void OnSerialized()
+        {
+            this.Age = 42;
+        }
+    }
+
     [AmqpContract(Name = "test.amqp:student", Code = 0x0000123400000001)]
     class Student : Person
     {


### PR DESCRIPTION
AMQP.Net lite currently supports an OnDeserialized annotation, but does not provide support for overriding OnSerialized. This patch allows just that.

**NOTE:** this is based on #22, I will rebase when that is merged and you won't see the duplicate work