### PR TITLE
refactor(Message): move GetBody definition into Message class

### DIFF
--- a/src/Message.cs
+++ b/src/Message.cs
@@ -108,6 +108,25 @@ namespace Amqp
             }
         }
 
+
+#if (DOTNET || DOTNET35)
+        /// <summary>
+        /// Gets an object of type T from the message body.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <returns></returns>
+        public T GetBody<T>()
+        {
+            if (this.BodySection != null &&
+                this.BodySection.Descriptor.Code == Codec.AmqpValue.Code)
+            {
+                return ((AmqpValue)this.BodySection).GetValue<T>();
+            }
+
+            return (T)this.Body;
+        }
+#endif
+
         /// <summary>
         /// Gets the delivery tag associated with the message.
         /// </summary>

--- a/src/Net/TaskExtensions.cs
+++ b/src/Net/TaskExtensions.cs
@@ -29,23 +29,6 @@ namespace Amqp
     public static class TaskExtensions
     {
 #if DOTNET
-        /// <summary>
-        /// Gets an object of type T from the message body.
-        /// </summary>
-        /// <typeparam name="T">The object type.</typeparam>
-        /// <param name="message">The message.</param>
-        /// <returns></returns>
-        public static T GetBody<T>(this Message message)
-        {
-            if (message.BodySection != null && 
-                message.BodySection.Descriptor.Code == Codec.AmqpValue.Code)
-            {
-                return ((AmqpValue)message.BodySection).GetValue<T>();
-            }
-
-            return (T)message.Body;
-        }
-
         static async Task<DeliveryState> GetTransactionalStateAsync(SenderLink sender)
         {
             return await Amqp.Transactions.ResourceManager.GetTransactionalStateAsync(sender);


### PR DESCRIPTION
GetBody is provided to access to a deserialized BodySection of a
Message, however, it was only provided as part of the extensions
for tasks. This moves it more accessibly directly on Message

closes #28 