### PR TITLE
Buffer manager support

### DIFF
--- a/Examples/Listener/Listener.IContainer/TestAmqpBroker.cs
+++ b/Examples/Listener/Listener.IContainer/TestAmqpBroker.cs
@@ -224,15 +224,23 @@ namespace Listener.IContainer
 
         sealed class BrokerMessage : Message
         {
+            ByteBuffer buffer;
             int messageOffset;
 
             public BrokerMessage(ByteBuffer buffer)
             {
-                this.Buffer = buffer;
+                this.buffer = buffer;
                 this.messageOffset = buffer.Offset;
             }
 
-            public ByteBuffer Buffer { get; private set; }
+            public ByteBuffer Buffer
+            {
+                get
+                {
+                    this.buffer.Seek(this.messageOffset);
+                    return this.buffer;
+                }
+            }
 
             public object LockedBy { get; set; }
 
@@ -241,7 +249,6 @@ namespace Listener.IContainer
             public void Unlock()
             {
                 this.LockedBy = null;
-                this.Buffer.Seek(this.messageOffset);
             }
         }
 

--- a/src/Amqp.Net.csproj
+++ b/src/Amqp.Net.csproj
@@ -58,6 +58,10 @@
     <Compile Include="Listener\IMessageProcessor.cs" />
     <Compile Include="Listener\Context.cs" />
     <Compile Include="Listener\ListenerLink.cs" />
+    <Compile Include="Net\BufferManager.cs" />
+    <Compile Include="Net\WrappedByteBuffer.cs" />
+    <Compile Include="Net\RefCountedByteBuffer.cs" />
+    <Compile Include="Net\IBufferManager.cs" />
     <Compile Include="Net\TcpSettings.cs" />
     <Compile Include="Net\AmqpSettings.cs" />
     <Compile Include="Net\ConnectionFactoryBase.cs" />

--- a/src/Amqp.NetCore.csproj
+++ b/src/Amqp.NetCore.csproj
@@ -102,9 +102,12 @@
     <Compile Include="Net\AmqpSettings.cs" />
     <Compile Include="Net\AsyncPump.cs" />
     <Compile Include="Net\IAsyncTransport.cs" />
+    <Compile Include="Net\IBufferManager.cs" />
+    <Compile Include="Net\RefCountedByteBuffer.cs" />
     <Compile Include="Net\TaskExtensions.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Net\WrappedByteBuffer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\StoreAssemblyInfo.cs" />
     <Compile Include="ReceiverLink.cs" />

--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -93,8 +93,10 @@ namespace Amqp
         /// Initializes a connection with SASL profile, open and open callback.
         /// </summary>
         /// <param name="address">The address.</param>
-        /// <param name="saslProfile">The SASL profile to do authentication (optional). If it is null and address has user info, SASL PLAIN profile is used.</param>
-        /// <param name="open">The open frame to send (optional). If not null, all mandatory fields must be set. Ensure that other fields are set to desired values.</param>
+        /// <param name="saslProfile">The SASL profile to do authentication (optional). If it is
+        /// null and address has user info, SASL PLAIN profile is used.</param>
+        /// <param name="open">The open frame to send (optional). If not null, all mandatory
+        /// fields must be set. Ensure that other fields are set to desired values.</param>
         /// <param name="onOpened">The callback to handle remote open frame (optional).</param>
         public Connection(Address address, SaslProfile saslProfile, Open open, OnOpened onOpened)
             : this(DefaultMaxSessions, DefaultMaxFrameSize)
@@ -120,10 +122,17 @@ namespace Amqp
             this.Connect(saslProfile, open);
         }
 
+        object ThisLock
+        {
+            get { return this; }
+        }
+
 #if DOTNET || NETFX_CORE
-        internal Connection(AmqpSettings amqpSettings, Address address, IAsyncTransport transport, Open open, OnOpened onOpened)
+        internal Connection(IBufferManager bufferManager, AmqpSettings amqpSettings, Address address,
+            IAsyncTransport transport, Open open, OnOpened onOpened)
             : this((ushort)(amqpSettings.MaxSessionsPerConnection - 1), (uint)amqpSettings.MaxFrameSize)
         {
+            this.BufferManager = bufferManager;
             this.address = address;
             this.onOpened = onOpened;
             this.maxFrameSize = (uint)amqpSettings.MaxFrameSize;
@@ -154,12 +163,33 @@ namespace Amqp
         {
             get { return new ConnectionFactory(); }
         }
-#endif
 
-        object ThisLock
+        internal IBufferManager BufferManager
         {
-            get { return this; }
+            get;
+            private set;
         }
+
+        ByteBuffer AllocateBuffer(int size)
+        {
+            return this.BufferManager.GetByteBuffer(size);
+        }
+
+        ByteBuffer WrapBuffer(ByteBuffer buffer, int offset, int length)
+        {
+            return new WrappedByteBuffer(buffer, offset, length);
+        }
+#else
+        ByteBuffer AllocateBuffer(int size)
+        {
+            return new ByteBuffer(size, true);
+        }
+
+        ByteBuffer WrapBuffer(ByteBuffer buffer, int offset, int length)
+        {
+            return new ByteBuffer(buffer.Buffer, buffer.Offset - offset, length, length);
+        }
+#endif
 
         internal ushort AddSession(Session session)
         {
@@ -194,18 +224,50 @@ namespace Amqp
         internal void SendCommand(ushort channel, DescribedList command)
         {
             this.ThrowIfClosed("Send");
-            ByteBuffer buffer = Frame.Encode(FrameType.Amqp, channel, command);
+            ByteBuffer buffer = this.AllocateBuffer(Frame.CmdBufferSize);
+            Frame.Encode(buffer, FrameType.Amqp, channel, command);
             this.transport.Send(buffer);
             Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1}", channel, command);
         }
 
-        internal void SendCommand(ushort channel, Transfer transfer, ByteBuffer payload)
+        internal int SendCommand(ushort channel, Transfer transfer, bool first, ByteBuffer payload, int reservedBytes)
         {
             this.ThrowIfClosed("Send");
-            int payloadSize;
-            ByteBuffer buffer = Frame.Encode(FrameType.Amqp, channel, transfer, payload, (int)this.maxFrameSize, out payloadSize);
-            this.transport.Send(buffer);
+            ByteBuffer buffer = this.AllocateBuffer(Frame.CmdBufferSize);
+            Frame.Encode(buffer, FrameType.Amqp, channel, transfer);
+            int payloadSize = payload.Length;
+            int frameSize = buffer.Length + payloadSize;
+            bool more = frameSize > this.maxFrameSize;
+            if (more)
+            {
+                transfer.More = true;
+                buffer.Reset();
+                Frame.Encode(buffer, FrameType.Amqp, channel, transfer);
+                frameSize = (int)this.maxFrameSize;
+                payloadSize = frameSize - buffer.Length;
+            }
+
+            AmqpBitConverter.WriteInt(buffer.Buffer, buffer.Offset, frameSize);
+
+            ByteBuffer frameBuffer;
+            if (first && !more && reservedBytes >= buffer.Length)
+            {
+                // optimize for most common case: single-transfer message
+                frameBuffer = this.WrapBuffer(payload, payload.Offset - buffer.Length, frameSize);
+                Array.Copy(buffer.Buffer, buffer.Offset, frameBuffer.Buffer, frameBuffer.Offset, buffer.Length);
+                buffer.ReleaseReference();
+            }
+            else
+            {
+                AmqpBitConverter.WriteBytes(buffer, payload.Buffer, payload.Offset, payloadSize);
+                frameBuffer = buffer;
+            }
+
+            payload.Complete(payloadSize);
+            this.transport.Send(frameBuffer);
             Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1} payload {2}", channel, transfer, payloadSize);
+
+            return payloadSize;
         }
 
         /// <summary>
@@ -490,7 +552,7 @@ namespace Amqp
             {
                 ushort channel;
                 DescribedList command;
-                Frame.GetFrame(buffer, out channel, out command);
+                Frame.Decode(buffer, out channel, out command);
                 if (buffer.Length > 0)
                 {
                     Trace.WriteLine(TraceLevel.Frame, "RECV (ch={0}) {1} payload {2}", channel, command, buffer.Length);

--- a/src/Delivery.cs
+++ b/src/Delivery.cs
@@ -25,6 +25,8 @@ namespace Amqp
 
         public ByteBuffer Buffer;
 
+        public int ReservedBufferSize;
+
         public uint Handle;
 
         public byte[] Tag;
@@ -72,6 +74,7 @@ namespace Amqp
                     delivery.OnOutcome(delivery.Message, outcome, delivery.UserToken);
                 }
 
+                delivery.Buffer.ReleaseReference();
                 delivery = (Delivery)delivery.Next;
             }
         }

--- a/src/Framing/AmqpValue.cs
+++ b/src/Framing/AmqpValue.cs
@@ -17,6 +17,7 @@
 
 namespace Amqp.Framing
 {
+    using System;
     using Amqp.Types;
 
     /// <summary>
@@ -34,27 +35,60 @@ namespace Amqp.Framing
         {
         }
 
+#if (DOTNET || DOTNET35)
+        ByteBuffer valueBuffer;
+        bool valueDecoded;
+        byte binaryOffset;
+
         /// <summary>
         /// Gets or sets the value in the body section.
         /// </summary>
         public object Value
         {
-            get { return this.value; }
-            set { this.value = value; }
-        }
+            get
+            {
+                if (!this.valueDecoded)
+                {
+                    this.value = Encoder.ReadObject(this.valueBuffer);
+                    this.valueDecoded = true;
+                }
 
-#if (DOTNET || DOTNET35)
-        ByteBuffer valueBuffer;
+                return this.value;
+            }
+            set
+            {
+                this.value = value;
+                this.valueDecoded = true;
+            }
+        }
 
         internal T GetValue<T>()
         {
-            if (this.value == null)
-            {
-                return default(T);
-            }
-            else if (typeof(T).IsAssignableFrom(this.value.GetType()))
+            if (this.value != null && typeof(T).IsAssignableFrom(this.value.GetType()))
             {
                 return (T)this.value;
+            }
+            else if (typeof(T) == typeof(ByteBuffer))
+            {
+                if (this.binaryOffset == 0)
+                {
+                    throw new ArgumentException("Body is not binary type.");
+                }
+
+                var payload = new ByteBuffer(this.valueBuffer.Buffer, this.valueBuffer.Offset + this.binaryOffset,
+                    this.valueBuffer.Length - this.binaryOffset, this.valueBuffer.Length - this.binaryOffset);
+                return (T)(object)payload;
+            }
+            else if (typeof(T) == typeof(byte[]))
+            {
+                if (this.binaryOffset == 0)
+                {
+                    throw new ArgumentException("Body is not binary type.");
+                }
+
+                byte[] payload = new byte[this.valueBuffer.Length - this.binaryOffset];
+                Buffer.BlockCopy(this.valueBuffer.Buffer, this.valueBuffer.Offset + this.binaryOffset, payload, 0, payload.Length);
+                return (T)(object)payload;
             }
             else
             {
@@ -64,18 +98,80 @@ namespace Amqp.Framing
 
         internal override void EncodeValue(ByteBuffer buffer)
         {
-            Serialization.AmqpSerializer.Serialize(buffer, this.value);
+            var byteBuffer = this.value as ByteBuffer;
+            if (byteBuffer != null)
+            {
+                Encoder.WriteBinaryBuffer(buffer, byteBuffer);
+            }
+            else
+            {
+                Serialization.AmqpSerializer.Serialize(buffer, this.value);
+            }
         }
 
         internal override void DecodeValue(ByteBuffer buffer)
         {
             int offset = buffer.Offset;
-            this.value = Encoder.ReadObject(buffer);
+            byte formatCode = Encoder.ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Binary8)
+            {
+                this.binaryOffset = 2;
+            }
+            else if (formatCode == FormatCode.Binary32)
+            {
+                this.binaryOffset = 5;
+            }
+            else
+            {
+                while (formatCode == FormatCode.Described)
+                {
+                    Encoder.ReadObject(buffer);
+                    formatCode = Encoder.ReadFormatCode(buffer);
+                }
+            }
 
-            int count = buffer.Offset - offset;
-            this.valueBuffer = new ByteBuffer(buffer.Buffer, offset, count, count);
+            int count;
+            if (formatCode >= 0xA0)
+            {
+                //bin8  a0 10100001
+                //str8  a1 10100001
+                //sym8  a3 10100011
+                //list8 c0 11000000
+                //map8  c1 11000001
+                //arr8  e0 11100000
+                //bin32 b0 10110000
+                //str32 b1 10110001
+                //sym32 b3 10110011
+                //lit32 d0 11010000
+                //map32 d1 11010001
+                //arr32 f0 11110000
+                if ((formatCode & 0x10) == 0)
+                {
+                    count = AmqpBitConverter.ReadUByte(buffer);
+                }
+                else
+                {
+                    count = AmqpBitConverter.ReadInt(buffer);
+                }
+            }
+            else
+            {
+                count = (1 << ((formatCode >> 4) - 4)) >> 1;
+            }
+
+            buffer.Validate(false, count);
+            buffer.Complete(count);
+
+            int size = buffer.Offset - offset;
+            this.valueBuffer = new ByteBuffer(buffer.Buffer, offset, size, size);
         }
 #else
+        public object Value
+        {
+            get { return this.value; }
+            set { this.value = value; }
+        }
+
         internal override void EncodeValue(ByteBuffer buffer)
         {
             Encoder.WriteObject(buffer, this.value);

--- a/src/Framing/Data.cs
+++ b/src/Framing/Data.cs
@@ -17,6 +17,7 @@
 
 namespace Amqp.Framing
 {
+    using System;
     using Amqp.Types;
 
     /// <summary>
@@ -24,6 +25,8 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Data : RestrictedDescribed
     {
+        byte[] binary;
+
         /// <summary>
         /// Initializes a Data object.
         /// </summary>
@@ -32,10 +35,33 @@ namespace Amqp.Framing
         {
         }
 
+#if (DOTNET || DOTNET35)
         /// <summary>
         /// Gets or sets the binary data in this section.
         /// </summary>
         public byte[] Binary
+        {
+            get
+            {
+                if (this.Buffer != null)
+                {
+                    byte[] temp = new byte[this.Buffer.Length];
+                    Array.Copy(this.Buffer.Buffer, this.Buffer.Offset, temp, 0, temp.Length);
+                    return temp;
+                }
+
+                return this.binary;
+            }
+            set
+            {
+                this.binary = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the binary data contained in a buffer in this section.
+        /// </summary>
+        public ByteBuffer Buffer
         {
             get;
             set;
@@ -43,12 +69,36 @@ namespace Amqp.Framing
 
         internal override void EncodeValue(ByteBuffer buffer)
         {
-            Encoder.WriteBinary(buffer, this.Binary, true);
+            if (this.Buffer != null)
+            {
+                Encoder.WriteBinaryBuffer(buffer, this.Buffer);
+            }
+            else
+            {
+                Encoder.WriteBinary(buffer, this.binary, true);
+            }
         }
 
         internal override void DecodeValue(ByteBuffer buffer)
         {
-            this.Binary = Encoder.ReadBinary(buffer, Encoder.ReadFormatCode(buffer));
+            this.Buffer = Encoder.ReadBinaryBuffer(buffer);
         }
+#else
+        public byte[] Binary
+        {
+            get { return this.binary; }
+            set { this.binary = value; }
+        }
+
+        internal override void EncodeValue(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, this.binary, true);
+        }
+
+        internal override void DecodeValue(ByteBuffer buffer)
+        {
+            this.binary = Encoder.ReadBinary(buffer, Encoder.ReadFormatCode(buffer));
+        }
+#endif
     }
 }

--- a/src/Framing/Frame.cs
+++ b/src/Framing/Frame.cs
@@ -17,7 +17,6 @@
 
 namespace Amqp.Framing
 {
-    using System;
     using Amqp.Types;
 
     enum FrameType : byte
@@ -28,51 +27,10 @@ namespace Amqp.Framing
 
     static class Frame
     {
+        public const int CmdBufferSize = 128;
         const byte DOF = 2;
-        const int cmdBufferSize = 128;
 
-        public static ByteBuffer Encode(FrameType type, ushort channel, DescribedList command)
-        {
-            ByteBuffer buffer = new ByteBuffer(cmdBufferSize, true);
-            EncodeFrame(buffer, type, channel, command);
-            AmqpBitConverter.WriteInt(buffer.Buffer, 0, buffer.Length);
-            return buffer;
-        }
-
-        public static ByteBuffer Encode(FrameType type, ushort channel, Transfer transfer,
-            ByteBuffer payload, int maxFrameSize, out int payloadSize)
-        {
-            int bufferSize = cmdBufferSize + payload.Length;
-            if (bufferSize > maxFrameSize)
-            {
-                bufferSize = maxFrameSize;
-            }
-
-            bool more = false;   // estimate it first
-            if (payload.Length > bufferSize - 32)
-            {
-                transfer.More = more = true;
-            }
-
-            ByteBuffer buffer = new ByteBuffer(bufferSize, false);
-            EncodeFrame(buffer, type, channel, transfer);
-
-            if (more && payload.Length <= buffer.Size)
-            {
-                // guessed it wrong. correct it
-                transfer.More = false;
-                buffer.Reset();
-                EncodeFrame(buffer, type, channel, transfer);
-            }
-
-            payloadSize = Math.Min(payload.Length, buffer.Size);
-            AmqpBitConverter.WriteBytes(buffer, payload.Buffer, payload.Offset, payloadSize);
-            payload.Complete(payloadSize);
-            AmqpBitConverter.WriteInt(buffer.Buffer, 0, buffer.Length);
-            return buffer;
-        }
-
-        public static void GetFrame(ByteBuffer buffer, out ushort channel, out DescribedList command)
+        public static void Decode(ByteBuffer buffer, out ushort channel, out DescribedList command)
         {
             AmqpBitConverter.ReadUInt(buffer);
             AmqpBitConverter.ReadUByte(buffer);
@@ -88,13 +46,14 @@ namespace Amqp.Framing
             }
         }
 
-        static void EncodeFrame(ByteBuffer buffer, FrameType type, ushort channel, DescribedList command)
+        public static void Encode(ByteBuffer buffer, FrameType type, ushort channel, DescribedList command)
         {
-            AmqpBitConverter.WriteUInt(buffer, 0u);
+            buffer.Append(FixedWidth.UInt);
             AmqpBitConverter.WriteUByte(buffer, DOF);
             AmqpBitConverter.WriteUByte(buffer, (byte)type);
             AmqpBitConverter.WriteUShort(buffer, channel);
             Codec.Encode(command, buffer);
+            AmqpBitConverter.WriteInt(buffer.Buffer, buffer.Offset, buffer.Length);
         }
     }
 }

--- a/src/Listener/ConnectionListener.cs
+++ b/src/Listener/ConnectionListener.cs
@@ -189,7 +189,7 @@ namespace Amqp.Listener
             if (this.saslSettings != null)
             {
                 ListenerSaslProfile profile = new ListenerSaslProfile(this);
-                transport = await profile.OpenAsync(null, transport);
+                transport = await profile.OpenAsync(null, this.BufferManager, transport);
             }
 
             Connection connection = new ListenerConnection(this, this.address, transport);
@@ -213,7 +213,7 @@ namespace Amqp.Listener
             }
             else
             {
-                AsyncPump pump = new AsyncPump(transport);
+                AsyncPump pump = new AsyncPump(this.BufferManager, transport);
                 pump.Start(connection);
             }
         }

--- a/src/Listener/Context.cs
+++ b/src/Listener/Context.cs
@@ -81,6 +81,7 @@ namespace Amqp.Listener
         protected void Dispose(DeliveryState deliveryState)
         {
             this.Link.DisposeMessage(this.Message, deliveryState, true);
+            this.Message.Dispose();
             this.state = ContextState.Completed;
         }
 

--- a/src/Listener/ListenerLink.cs
+++ b/src/Listener/ListenerLink.cs
@@ -264,33 +264,23 @@ namespace Amqp.Listener
         {
             if (delivery != null)
             {
+                buffer.AddReference();
+                delivery.Buffer = buffer;
                 this.deliveryCount++;
-                if (!transfer.More)
-                {
-                    // single transfer message - the most common case
-                    delivery.Buffer = buffer;
-                    this.DeliverMessage(delivery);
-                }
-                else
-                {
-                    delivery.Buffer = new ByteBuffer(buffer.Length * 2, true);
-                    AmqpBitConverter.WriteBytes(delivery.Buffer, buffer.Buffer, buffer.Offset, buffer.Length);
-                    this.deliveryCurrent = delivery;
-                }
             }
             else
             {
                 delivery = this.deliveryCurrent;
-                if (!transfer.More)
-                {
-                    AmqpBitConverter.WriteBytes(delivery.Buffer, buffer.Buffer, buffer.Offset, buffer.Length);
-                    this.deliveryCurrent = null;
-                    this.DeliverMessage(delivery);
-                }
-                else
-                {
-                    AmqpBitConverter.WriteBytes(delivery.Buffer, buffer.Buffer, buffer.Offset, buffer.Length);
-                }
+                AmqpBitConverter.WriteBytes(delivery.Buffer, buffer.Buffer, buffer.Offset, buffer.Length);
+            }
+
+            if (!transfer.More)
+            {
+                this.DeliverMessage(delivery);
+            }
+            else
+            {
+                this.deliveryCurrent = delivery;
             }
         }
 

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -108,7 +108,6 @@ namespace Amqp
             }
         }
 
-
 #if (DOTNET || DOTNET35)
         /// <summary>
         /// Gets an object of type T from the message body.
@@ -117,10 +116,24 @@ namespace Amqp
         /// <returns></returns>
         public T GetBody<T>()
         {
-            if (this.BodySection != null &&
-                this.BodySection.Descriptor.Code == Codec.AmqpValue.Code)
+            if (this.BodySection != null)
             {
-                return ((AmqpValue)this.BodySection).GetValue<T>();
+                if (this.BodySection.Descriptor.Code == Codec.AmqpValue.Code)
+                {
+                    return ((AmqpValue)this.BodySection).GetValue<T>();
+                }
+                else if (this.BodySection.Descriptor.Code == Codec.Data.Code)
+                {
+                    Data data = (Data)this.BodySection;
+                    if (typeof(T) == typeof(byte[]))
+                    {
+                        return (T)(object)data.Binary;
+                    }
+                    else if (typeof(T) == typeof(ByteBuffer))
+                    {
+                        return (T)(object)data.Buffer;
+                    }
+                }
             }
 
             return (T)this.Body;
@@ -150,15 +163,7 @@ namespace Amqp
         /// <returns>The buffer.</returns>
         public ByteBuffer Encode()
         {
-            ByteBuffer buffer = new ByteBuffer(128, true);
-            EncodeIfNotNull(this.Header, buffer);
-            EncodeIfNotNull(this.DeliveryAnnotations, buffer);
-            EncodeIfNotNull(this.MessageAnnotations, buffer);
-            EncodeIfNotNull(this.Properties, buffer);
-            EncodeIfNotNull(this.ApplicationProperties, buffer);
-            EncodeIfNotNull(this.BodySection, buffer);
-            EncodeIfNotNull(this.Footer, buffer);
-            return buffer;
+            return this.Encode(0);
         }
 
         /// <summary>
@@ -213,6 +218,13 @@ namespace Amqp
             return message;
         }
 
+        internal ByteBuffer Encode(int reservedBytes)
+        {
+            ByteBuffer buffer = new ByteBuffer(reservedBytes + 128, true);
+            this.WriteToBuffer(buffer);
+            return buffer;
+        }
+
         static void EncodeIfNotNull(RestrictedDescribed section, ByteBuffer buffer)
         {
             if (section != null)
@@ -220,5 +232,88 @@ namespace Amqp
                 section.Encode(buffer);
             }
         }
+
+        void WriteToBuffer(ByteBuffer buffer)
+        {
+            EncodeIfNotNull(this.Header, buffer);
+            EncodeIfNotNull(this.DeliveryAnnotations, buffer);
+            EncodeIfNotNull(this.MessageAnnotations, buffer);
+            EncodeIfNotNull(this.Properties, buffer);
+            EncodeIfNotNull(this.ApplicationProperties, buffer);
+            EncodeIfNotNull(this.BodySection, buffer);
+            EncodeIfNotNull(this.Footer, buffer);
+        }
+
+#if DOTNET
+        /// <summary>
+        /// Disposes the current message to release resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.Delivery != null &&
+                this.Delivery.Buffer != null)
+            {
+                this.Delivery.Buffer.ReleaseReference();
+            }
+        }
+
+        internal ByteBuffer Encode(IBufferManager bufferManager, int reservedBytes)
+        {
+            // get some extra space to store the frame header
+            // and the transfer command.
+            int size = reservedBytes + this.GetEstimatedMessageSize();
+            ByteBuffer buffer = bufferManager.GetByteBuffer(size);
+            buffer.AdjustPosition(buffer.Offset + reservedBytes, 0);
+            this.WriteToBuffer(buffer);
+            return buffer;
+        }
+
+        static int GetEstimatedBodySize(RestrictedDescribed body)
+        {
+            var data = body as Data;
+            if (data != null)
+            {
+                if (data.Buffer != null)
+                {
+                    return data.Buffer.Length;
+                }
+                else
+                {
+                    return data.Binary.Length;
+                }
+            }
+
+            var value = body as AmqpValue;
+            if (value != null)
+            {
+                var b = value.Value as byte[];
+                if (b != null)
+                {
+                    return b.Length;
+                }
+
+                var f = value.Value as ByteBuffer;
+                if (f != null)
+                {
+                    return f.Length;
+                }
+            }
+
+            return 64;
+        }
+
+        int GetEstimatedMessageSize()
+        {
+            int size = 0;
+            if (this.Header != null) size += 64;
+            if (this.DeliveryAnnotations != null) size += 64;
+            if (this.MessageAnnotations != null) size += 64;
+            if (this.Properties != null) size += 64;
+            if (this.ApplicationProperties != null) size += 64;
+            if (this.BodySection != null) size += GetEstimatedBodySize(this.BodySection) + 8;
+            if (this.Footer != null) size += 64;
+            return size;
+        }
+#endif
     }
 }

--- a/src/Net/BufferManager.cs
+++ b/src/Net/BufferManager.cs
@@ -1,0 +1,172 @@
+﻿//  ------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation
+//  All rights reserved. 
+//  
+//  Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this 
+//  file except in compliance with the License. You may obtain a copy of the License at 
+//  http://www.apache.org/licenses/LICENSE-2.0  
+//  
+//  THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+//  EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR 
+//  CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR 
+//  NON-INFRINGEMENT. 
+// 
+//  See the Apache Version 2.0 License for specific language governing permissions and 
+//  limitations under the License.
+//  ------------------------------------------------------------------------------------
+
+namespace Amqp
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    /// <summary>
+    /// A BufferManager manages pooled buffers (byte arrays) with different sizes.
+    /// </summary>
+    public class BufferManager : IBufferManager
+    {
+        int minBufferSize;
+        int maxBufferSize;
+        long maxMemorySize;
+        long currentMemorySize;
+        int indexOffset;
+        List<Pool> bufferPools;
+
+        /// <summary>
+        /// Initializes a new instance of the BufferManager class.
+        /// </summary>
+        /// <param name="minBufferSize">The minimum size of pooled buffers.</param>
+        /// <param name="maxBufferSize">The maximum size of pooled buffers.</param>
+        /// <param name="maxMemorySize">The maximum totoal size of pooled buffers.</param>
+        public BufferManager(int minBufferSize, int maxBufferSize, long maxMemorySize)
+        {
+            CheckBufferSize(minBufferSize, "minBufferSize");
+            CheckBufferSize(maxBufferSize, "maxBufferSize");
+            this.minBufferSize = minBufferSize;
+            this.maxBufferSize = maxBufferSize;
+            this.maxMemorySize = maxMemorySize;
+            this.indexOffset = RoundToNextLog2(minBufferSize);
+            this.bufferPools = new List<Pool>();
+
+            int size = minBufferSize;
+            while (size <= maxBufferSize)
+            {
+                this.bufferPools.Add(new Pool(size));
+                size *= 2;
+            }
+        }
+
+        ArraySegment<byte> IBufferManager.TakeBuffer(int bufferSize)
+        {
+            if (bufferSize > this.maxBufferSize)
+            {
+                return new ArraySegment<byte>(new byte[bufferSize]);
+            }
+
+            int index = bufferSize <= this.minBufferSize ? 0 : RoundToNextLog2(bufferSize) - this.indexOffset;
+            Pool pool = this.bufferPools[index];
+            byte[] buffer;
+            if (pool.TryTake(bufferSize, out buffer))
+            {
+                Interlocked.Add(ref this.currentMemorySize, -buffer.Length);
+            }
+            else
+            {
+                buffer = new byte[pool.BufferSize];
+            }
+
+            return new ArraySegment<byte>(buffer);
+        }
+
+        void IBufferManager.ReturnBuffer(ArraySegment<byte> buffer)
+        {
+            int bufferSize = buffer.Array.Length;
+            if (bufferSize > this.maxBufferSize)
+            {
+                return;
+            }
+
+            int index = bufferSize <= this.minBufferSize ? 0 : RoundToNextLog2(bufferSize) - this.indexOffset;
+            Pool pool = this.bufferPools[index];
+            if (bufferSize == pool.BufferSize && this.currentMemorySize < this.maxMemorySize)
+            {
+                Interlocked.Add(ref this.currentMemorySize, pool.BufferSize);
+                pool.Return(buffer.Array);
+            }
+        }
+
+        static void CheckBufferSize(int bufferSize, string name)
+        {
+            if (bufferSize <= 0 || !IsPowerOfTwo(bufferSize))
+            {
+                throw new ArgumentException(name);
+            }
+        }
+
+        static bool IsPowerOfTwo(int number)
+        {
+            return (number & (number - 1)) == 0;
+        }
+
+        static readonly int[] MultiplyDeBruijnBitPosition = 
+        {
+            0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8, 
+            31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+        };
+
+        static int RoundToNextLog2(int bufferSize)
+        {
+            uint v = (uint)bufferSize;
+            if (!IsPowerOfTwo(bufferSize))
+            {
+                v--;
+                v |= v >> 1;
+                v |= v >> 2;
+                v |= v >> 4;
+                v |= v >> 8;
+                v |= v >> 16;
+                v++;
+            }
+
+            return MultiplyDeBruijnBitPosition[(v * 0x077CB531U) >> 27];
+        }
+
+        class Pool
+        {
+            ConcurrentQueue<byte[]> buffers;
+
+            public Pool(int bufferSize)
+            {
+                this.BufferSize = bufferSize;
+                this.buffers = new ConcurrentQueue<byte[]>();
+            }
+
+            public int BufferSize
+            {
+                get;
+                private set;
+            }
+
+            public bool TryTake(int size, out byte[] buffer)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    if (this.buffers.TryDequeue(out buffer))
+                    {
+                        return true;
+                    }
+                }
+
+                buffer = null;
+                return false;
+            }
+
+            public void Return(byte[] buffer)
+            {
+                this.buffers.Enqueue(buffer);
+            }
+        }
+    }
+}

--- a/src/Net/ConnectionFactory.cs
+++ b/src/Net/ConnectionFactory.cs
@@ -103,15 +103,15 @@ namespace Amqp
             if (address.User != null)
             {
                 SaslPlainProfile profile = new SaslPlainProfile(address.User, address.Password);
-                transport = await profile.OpenAsync(address.Host, transport);
+                transport = await profile.OpenAsync(address.Host, this.BufferManager, transport);
             }
             else if (this.saslSettings != null && this.saslSettings.Profile != null)
             {
-                transport = await this.saslSettings.Profile.OpenAsync(address.Host, transport);
+                transport = await this.saslSettings.Profile.OpenAsync(address.Host, this.BufferManager, transport);
             }
 
-            AsyncPump pump = new AsyncPump(transport);
-            Connection connection = new Connection(this.AMQP, address, transport, open, onOpened);
+            AsyncPump pump = new AsyncPump(this.BufferManager, transport);
+            Connection connection = new Connection(this.BufferManager, this.AMQP, address, transport, open, onOpened);
             pump.Start(connection);
 
             return connection;

--- a/src/Net/ConnectionFactoryBase.cs
+++ b/src/Net/ConnectionFactoryBase.cs
@@ -47,6 +47,15 @@ namespace Amqp
         }
 
         /// <summary>
+        /// Gets or sets a buffer manager used by the connection factory.
+        /// </summary>
+        public IBufferManager BufferManager
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets the TCP settings on the factory.
         /// </summary>
         public TcpSettings TCP

--- a/src/Net/IBufferManager.cs
+++ b/src/Net/IBufferManager.cs
@@ -1,0 +1,46 @@
+﻿//  ------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation
+//  All rights reserved. 
+//  
+//  Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this 
+//  file except in compliance with the License. You may obtain a copy of the License at 
+//  http://www.apache.org/licenses/LICENSE-2.0  
+//  
+//  THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+//  EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR 
+//  CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR 
+//  NON-INFRINGEMENT. 
+// 
+//  See the Apache Version 2.0 License for specific language governing permissions and 
+//  limitations under the License.
+//  ------------------------------------------------------------------------------------
+
+namespace Amqp
+{
+    using System;
+
+#if DOTNET
+    /// <summary>
+    /// The interface defines the methods to manage buffers.
+    /// </summary>
+    public
+#endif
+    interface IBufferManager
+    {
+        /// <summary>
+        /// Takes a buffer from the buffer manager.
+        /// </summary>
+        /// <param name="bufferSize">the buffer size.</param>
+        /// <returns>
+        /// A segment of a byte array. The count should be the same, or larger
+        /// than the requested bufferSize.
+        /// </returns>
+        ArraySegment<byte> TakeBuffer(int bufferSize);
+
+        /// <summary>
+        /// Returns a buffer to the buffer manager.
+        /// </summary>
+        /// <param name="buffer">The buffer to return.</param>
+        void ReturnBuffer(ArraySegment<byte> buffer);
+    }
+}

--- a/src/Net/RefCountedByteBuffer.cs
+++ b/src/Net/RefCountedByteBuffer.cs
@@ -1,0 +1,67 @@
+﻿//  ------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation
+//  All rights reserved. 
+//  
+//  Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this 
+//  file except in compliance with the License. You may obtain a copy of the License at 
+//  http://www.apache.org/licenses/LICENSE-2.0  
+//  
+//  THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+//  EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR 
+//  CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR 
+//  NON-INFRINGEMENT. 
+// 
+//  See the Apache Version 2.0 License for specific language governing permissions and 
+//  limitations under the License.
+//  ------------------------------------------------------------------------------------
+
+namespace Amqp
+{
+    using System;
+    using System.Threading;
+
+    class RefCountedByteBuffer : ByteBuffer
+    {
+        readonly IBufferManager bufferManager;
+        int references;
+
+        internal RefCountedByteBuffer(IBufferManager bufferManager, byte[] buffer, int offset, int count, int length)
+            : base(buffer, offset, length, count, true)
+        {
+            this.bufferManager = bufferManager;
+            this.references = 1;
+        }
+
+        internal IBufferManager BufferManager
+        {
+            get { return this.bufferManager; }
+        }
+
+        internal override void AddReference()
+        {
+            if (Interlocked.Increment(ref this.references) <= 1)
+            {
+                Interlocked.Decrement(ref this.references);
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+        }
+
+        internal override void ReleaseReference()
+        {
+            if (Interlocked.Decrement(ref this.references) == 0)
+            {
+                this.bufferManager.ReturnBuffer(this.ToArraySegment());
+            }
+        }
+
+        internal override void DuplicateBuffer(int bufferSize, int dataSize, out byte[] buffer, out int offset, out int count)
+        {
+            var segment = this.bufferManager.TakeBuffer(bufferSize);
+            buffer = segment.Array;
+            offset = segment.Offset;
+            count = segment.Count;
+            System.Buffer.BlockCopy(this.Buffer, this.Start, segment.Array, segment.Offset, dataSize);
+            this.bufferManager.ReturnBuffer(this.ToArraySegment());
+        }
+    }
+}

--- a/src/NetCore/ConnectionFactory.cs
+++ b/src/NetCore/ConnectionFactory.cs
@@ -99,15 +99,15 @@ namespace Amqp
             if (address.User != null)
             {
                 SaslPlainProfile profile = new SaslPlainProfile(address.User, address.Password);
-                transport = await profile.OpenAsync(address.Host, transport);
+                transport = await profile.OpenAsync(address.Host, null, transport);
             }
             else if (this.saslSettings != null && this.saslSettings.Profile != null)
             {
-                transport = await this.saslSettings.Profile.OpenAsync(address.Host, transport);
+                transport = await this.saslSettings.Profile.OpenAsync(address.Host, null, transport);
             }
 
-            AsyncPump pump = new AsyncPump(transport);
-            Connection connection = new Connection(this.AMQP, address, transport, open, onOpened);
+            AsyncPump pump = new AsyncPump(null, transport);
+            Connection connection = new Connection(null, this.AMQP, address, transport, open, onOpened);
             pump.Start(connection);
 
             return connection;

--- a/src/Sasl/SaslProfile.cs
+++ b/src/Sasl/SaslProfile.cs
@@ -101,7 +101,7 @@ namespace Amqp.Sasl
         {
             ushort channel;
             DescribedList command;
-            Frame.GetFrame(buffer, out channel, out command);
+            Frame.Decode(buffer, out channel, out command);
             Trace.WriteLine(TraceLevel.Frame, "RECV {0}", command);
 
             bool shouldContinue = true;
@@ -160,7 +160,8 @@ namespace Amqp.Sasl
 
         void SendCommand(ITransport transport, DescribedList command)
         {
-            ByteBuffer buffer = Frame.Encode(FrameType.Sasl, 0, command);
+            ByteBuffer buffer = new ByteBuffer(Frame.CmdBufferSize, true);
+            Frame.Encode(buffer, FrameType.Sasl, 0, command);
             transport.Send(buffer);
             Trace.WriteLine(TraceLevel.Frame, "SEND {0}", command);
         }

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -151,7 +151,12 @@ namespace Amqp
 
         internal void Send(Message message, DeliveryState deliveryState, OutcomeCallback callback, object state)
         {
-            var buffer = message.Encode();
+            const int reservedBytes = 40;
+#if DOTNET
+            var buffer = message.Encode(this.Session.Connection.BufferManager, reservedBytes);
+#else
+            var buffer = message.Encode(reservedBytes);
+#endif
             if (buffer.Length < 1)
             {
                 throw new ArgumentException("Cannot send an empty message.");
@@ -161,6 +166,7 @@ namespace Amqp
             {
                 Message = message,
                 Buffer = buffer,
+                ReservedBufferSize = reservedBytes,
                 State = deliveryState,
                 Link = this,
                 OnOutcome = callback,

--- a/src/Session.cs
+++ b/src/Session.cs
@@ -562,12 +562,13 @@ namespace Amqp
         void WriteDelivery(Delivery delivery)
         {
             // Must be called under lock. Delivery must be on list already
-            while (this.outgoingWindow > 0 && delivery != null && delivery.Buffer.Length > 0)
+            while (this.outgoingWindow > 0 && delivery != null)
             {
                 --this.outgoingWindow;
                 Transfer transfer = new Transfer() { Handle = delivery.Handle };
 
-                if (delivery.BytesTransfered == 0)
+                bool first = delivery.BytesTransfered == 0;
+                if (first)
                 {
                     // initialize properties for first transfer
                     delivery.DeliveryId = this.outgoingDeliveryId++;
@@ -579,13 +580,13 @@ namespace Amqp
                     transfer.Batchable = true;
                 }
 
-                int len = delivery.Buffer.Length;
-                this.connection.SendCommand(this.channel, transfer, delivery.Buffer);
-                delivery.BytesTransfered += len - delivery.Buffer.Length;
+                int len = this.connection.SendCommand(this.channel, transfer, first,
+                    delivery.Buffer, delivery.ReservedBufferSize);
+                delivery.BytesTransfered += len;
 
                 if (delivery.Buffer.Length == 0)
                 {
-                    delivery.Buffer = null;
+                    delivery.Buffer.ReleaseReference();
                     Delivery next = (Delivery)delivery.Next;
                     if (delivery.Settled)
                     {

--- a/test/PerfTest/Arguments.cs
+++ b/test/PerfTest/Arguments.cs
@@ -84,6 +84,10 @@ namespace PerfTest
             {
                 obj = int.Parse(value);
             }
+            else if (type == typeof(bool))
+            {
+                return true;
+            }
             else
             {
                 throw new NotSupportedException(type.Name);

--- a/test/Test.Amqp.Net/AmqpCodecTests.cs
+++ b/test/Test.Amqp.Net/AmqpCodecTests.cs
@@ -431,6 +431,11 @@ namespace Test.Amqp
                     continue;
                 }
 
+                if (type.GetConstructor(new Type[0]) == null)
+                {
+                    continue;
+                }
+
                 System.Diagnostics.Trace.WriteLine("testing " + type.FullName);
 
                 object obj = CreateRestrictedDescribed(type, random);


### PR DESCRIPTION
#21 GC: support buffer manager to help GC time and allocations.

Add IBufferManager to connection factory and listener
Add a default simple buffer manager implementation
Add Message.Dispose method to release associated buffer
Release the buffer when MessageContext is completed
Allow ByteBuffer on AmqpValue and Data to avoid bytes copy
Update perf test to use default buffer manager
Remove one bytes copy in message encoding for common cases