### PR TITLE
CoreCLR support

### DIFF
--- a/dnx/Amqp.DotNet/project.json
+++ b/dnx/Amqp.DotNet/project.json
@@ -17,6 +17,10 @@
     "../../src/*.cs"
   ],
 
+  "namedResource": {
+  	"Amqp.SRAmqp": "../../src/SRAmqp.resx"
+  },
+
   "frameworks": {
     "net45": {
       "compilationOptions": {
@@ -38,7 +42,7 @@
         "System.Transactions": ""
       }
     },
-    "dotnet": {
+    "dnxcore50": {
       "compilationOptions": {
         "allowUnsafe": true,
         "define": [ "TRACE", "DOTNET" ]
@@ -55,7 +59,7 @@
         "System.Threading.Timer": "4.0.1-beta-23409",
         "System.Net.NameResolution": "4.0.0-beta-23409",
         "System.Net.Security": "4.0.0-beta-23409",
-        "System.Net.Sockets": "4.0.10-beta-23019",
+        "System.Net.Sockets":  "4.1.0-beta-23516",
         "System.Reflection": "4.0.0",
         "System.Reflection.Emit.Lightweight": "4.0.1-beta-23409",
         "System.Reflection.Extensions": "4.0.1-beta-23409",

--- a/src/Listener/ConnectionListener.cs
+++ b/src/Listener/ConnectionListener.cs
@@ -507,11 +507,7 @@ namespace Amqp.Listener
                 {
                     try
                     {
-                        Socket acceptSocket = await Task.Factory.FromAsync(
-                            (c, s) => ((Socket)s).BeginAccept(c, s),
-                            (r) => ((Socket)r.AsyncState).EndAccept(r),
-                            socket);
-
+                        Socket acceptSocket = await socket.AcceptAsync();
                         var task = this.HandleSocketAsync(acceptSocket);
                     }
                     catch (ObjectDisposedException)


### PR DESCRIPTION
1. Change target from 'dotnet' to 'dnxcore50'
2. Add SRAmqp.resx via namedResource
3. Remove references to obsolete Socket.Begin*/End* methods, rewriting them in terms of *Async ones.

fixes #43 