### PR TITLE
Friendly protocol failure

### DIFF
--- a/src/Framing/ProtocolHeader.cs
+++ b/src/Framing/ProtocolHeader.cs
@@ -38,7 +38,7 @@ namespace Amqp.Framing
                 buffer[offset + 2] != (byte)Protocol[2] ||
                 buffer[offset + 3] != (byte)Protocol[3])
             {
-                throw new AmqpException(ErrorCode.InvalidField, string.Format("Unexpected protocol name in the header. Expected {0}, but received {1}.", Protocol, Encoding.ASCII.GetString(buffer, offset, 4)));
+                throw new AmqpException(ErrorCode.InvalidField, string.Format("Unexpected protocol name in the header. Expected {0}, but received {1}.", Protocol, Encoding.UTF8.GetString(buffer, offset, 4)));
             }
 
             return new ProtocolHeader()

--- a/src/Framing/ProtocolHeader.cs
+++ b/src/Framing/ProtocolHeader.cs
@@ -17,7 +17,7 @@
 
 namespace Amqp.Framing
 {
-    using Amqp.Types;
+    using System.Text;
 
     struct ProtocolHeader
     {
@@ -31,12 +31,14 @@ namespace Amqp.Framing
 
         public static ProtocolHeader Create(byte[] buffer, int offset)
         {
-            if (buffer[offset + 0] != (byte)'A' ||
-                buffer[offset + 1] != (byte)'M' ||
-                buffer[offset + 2] != (byte)'Q' ||
-                buffer[offset + 3] != (byte)'P')
+            const string Protocol = "AMQP";
+
+            if (buffer[offset + 0] != (byte)Protocol[0] ||
+                buffer[offset + 1] != (byte)Protocol[1] ||
+                buffer[offset + 2] != (byte)Protocol[2] ||
+                buffer[offset + 3] != (byte)Protocol[3])
             {
-                throw new AmqpException(ErrorCode.InvalidField, "ProtocolName");
+                throw new AmqpException(ErrorCode.InvalidField, string.Format("Unexpected protocol name in the header. Expected {0}, but received {1}.", Protocol, Encoding.ASCII.GetString(buffer, offset, 4)));
             }
 
             return new ProtocolHeader()


### PR DESCRIPTION
This is to make protocol mismatches easier to troubleshoot. This helped me troubleshoot issue https://github.com/Azure/amqpnetlite/issues/106. Previously, the trace would show a failure in the protocol header, but not why it failed. Now it gives a little more information to take the next step troubleshooting.

All tests in Test.Amqp.Net pass for me locally.