### PR TITLE
Add explicit warning that TLS SNI is absent when using numeric IP addresses

### DIFF
--- a/src/Address.cs
+++ b/src/Address.cs
@@ -28,6 +28,8 @@ namespace Amqp
     /// If "amqps" is specified, the connection uses TLS in the underlying transport.
     /// When port is not specified, it is set to the standard based on scheme (amqp: 5672, amqps: 5671)
     /// path is not used by the library.
+    /// Note that TLS Server Name Indication (SNI) is signaled only for "amqps" addresses where
+    /// the domain is host | name. SNI is not signaled when the domain is a numeric IP address.
     /// </summary>
     public sealed class Address
     {


### PR DESCRIPTION
TLS SNI is important in emerging IoT networks. Amqpnetlite fully supports TLS SNI unless the user provides a numeric IP address to the connection URL. See discussion in https://github.com/Azure/amqpnetlite/issues/92

This patch is a simple doc comment alerting the user how to make TLS SNI work as expected.