### PR TITLE
Issue #126 Fix infinite recursion: remove bad function that hides builtin method

### DIFF
--- a/src/Net35/ConcurrentDictionary.cs
+++ b/src/Net35/ConcurrentDictionary.cs
@@ -28,14 +28,6 @@ namespace System.Collections.Concurrent
             this.syncRoot = new object();
         }
 
-        public new bool TryGetValue(TKey key, out TValue value)
-        {
-            lock (this.syncRoot)
-            {
-                return this.TryGetValue(key, out value);
-            }
-        }
-
         public TValue GetOrAdd(TKey key, TValue value)
         {
             lock (this.syncRoot)


### PR DESCRIPTION
The code seems to work by just removing the function that recurses. This function is hiding a builtin method that apparently does the same thing.