### PR TITLE
feat(SimpleList): support serializing types as simple lists

### DIFF
--- a/src/Serialization/AmqpContractAttribute.cs
+++ b/src/Serialization/AmqpContractAttribute.cs
@@ -52,6 +52,9 @@ namespace Amqp.Serialization
     /// SimpleMap: value encoding is the same as Map except that the keys are AMQP string.
     /// Because this encoding does not have descriptors, decoding an object with a base type
     /// decorated with AmqpProvidesAttribute is not supported.
+    /// SimpleList: value encoding is the same as List except that no initial descriptor is
+    /// written. Because this encoding does not have descriptors, decoding an object with a
+    /// base type decorated with AmqpProvidesAttribute is not supported.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct,
         AllowMultiple = false, Inherited = true)]

--- a/src/Serialization/AmqpSerializer.cs
+++ b/src/Serialization/AmqpSerializer.cs
@@ -279,6 +279,13 @@ namespace Amqp.Serialization
                     Fx.Format("{0}: SimpleMap encoding does not include descriptors so it does not support AmqpProvidesAttribute.", type.Name));
             }
 
+            if (contractAttribute.Encoding == EncodingType.SimpleList &&
+                type.GetCustomAttribute<AmqpProvidesAttribute>(false) != null)
+            {
+                throw new SerializationException(
+                    Fx.Format("{0}: SimpleList encoding does not include descriptors so it does not support AmqpProvidesAttribute.", type.Name));
+            }
+
             Dictionary<Type, SerializableType> knownTypes = null;
             var providesAttributes = type.GetCustomAttributes<AmqpProvidesAttribute>(false);
             foreach (object o in providesAttributes)
@@ -309,6 +316,10 @@ namespace Amqp.Serialization
             else if (contractAttribute.Encoding == EncodingType.SimpleMap)
             {
                 return SerializableType.CreateDescribedSimpleMapType(this, type, baseType, members, serializationCallbacks);
+            }
+            else if (contractAttribute.Encoding == EncodingType.SimpleList)
+            {
+                return SerializableType.CreateDescribedSimpleListType(this, type, baseType, members, serializationCallbacks);
             }
             else
             {

--- a/src/Serialization/EncodingType.cs
+++ b/src/Serialization/EncodingType.cs
@@ -36,5 +36,10 @@ namespace Amqp.Serialization
         /// The type is encoded as an AMQP map with string keys.
         /// </summary>
         SimpleMap,
+
+        /// <summary>
+        /// The type is encoded as an AMQP list with no descriptor.
+        /// </summary>
+        SimpleList,
     }
 }

--- a/test/Common/Types/Negative.cs
+++ b/test/Common/Types/Negative.cs
@@ -64,4 +64,21 @@ namespace Test.Amqp
         [AmqpMember]
         public int Field1;
     }
+
+    // SimpleList encoding has AmqpProvides attribute
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    [AmqpProvides(typeof(NegativeSimpleListNoProvides))]
+    abstract class NegativeSimpleListNoProvidesBase
+    {
+        [AmqpMember]
+        public string Name { get; set; }
+    }
+
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    class NegativeSimpleListNoProvides : NegativeSimpleListNoProvidesBase
+    {
+        [AmqpMember]
+        public int Field1;
+    }
 }
+

--- a/test/Common/Types/Operation.cs
+++ b/test/Common/Types/Operation.cs
@@ -58,4 +58,45 @@ namespace Test.Amqp
         [AmqpMember]
         public SquareRootOperation SquareRoot { get; set; }
     }
+
+    // SimpleList encoded variants of the above
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    abstract class ListOperation
+    {
+        [AmqpMember]
+        public string Name;
+
+        [AmqpMember]
+        public int Version { get; set; }
+    }
+
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    class ListAddOperation : ListOperation
+    {
+        [AmqpMember]
+        public int Param1;
+
+        [AmqpMember]
+        public int Param2;
+    }
+
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    class ListSquareRootOperation : ListOperation
+    {
+        [AmqpMember]
+        public long Param;
+    }
+
+    [AmqpContract(Encoding = EncodingType.SimpleList)]
+    class ListMultiOperation : ListOperation
+    {
+        [AmqpMember]
+        public string Instruction { get; set; }
+
+        [AmqpMember]
+        public AddOperation Add { get; set; }
+
+        [AmqpMember]
+        public SquareRootOperation SquareRoot { get; set; }
+    }
 }


### PR DESCRIPTION
This feature mirrors the support for a SimpleMap encoding, allowing users to serialize their types as a plain AMQP list32 with no leading descriptor.

resolves #131 