### PR TITLE
Fix log time-of-day specification string.

### DIFF
--- a/Examples/Interop/Interop.Client/Interop.Client.cs
+++ b/Examples/Interop/Interop.Client/Interop.Client.cs
@@ -51,7 +51,7 @@ namespace Examples.Interop
             Connection.DisableServerCertValidation = true;
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Connection connection = null;
             try

--- a/Examples/Interop/Interop.Server/Interop.Server.cs
+++ b/Examples/Interop/Interop.Server/Interop.Server.cs
@@ -52,7 +52,7 @@ namespace Interop.Server
             Connection.DisableServerCertValidation = true;
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Connection connection = null;
             try

--- a/Examples/Listener/Listener.ContainerHost/Program.cs
+++ b/Examples/Listener/Listener.ContainerHost/Program.cs
@@ -39,7 +39,7 @@ namespace Listener.ContainerHost
 
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Uri addressUri = new Uri(address);
             ContainerHost host = new ContainerHost(new Uri[] { addressUri }, null, addressUri.UserInfo);

--- a/Examples/PeerToPeer/PeerToPeer.Certificate/Program.cs
+++ b/Examples/PeerToPeer/PeerToPeer.Certificate/Program.cs
@@ -29,7 +29,7 @@ namespace PeerToPeer.Certificate
         static void Main(string[] args)
         {
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             string address = "amqps://localhost:5671";
 

--- a/Examples/PeerToPeer/PeerToPeer.Client/Program.cs
+++ b/Examples/PeerToPeer/PeerToPeer.Client/Program.cs
@@ -34,7 +34,7 @@ namespace PeerToPeer.Client
 
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Console.WriteLine("Running request client...");
             new Client(address).Run();

--- a/Examples/PeerToPeer/PeerToPeer.Receiver/Program.cs
+++ b/Examples/PeerToPeer/PeerToPeer.Receiver/Program.cs
@@ -37,7 +37,7 @@ namespace PeerToPeer.Server
 
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Uri addressUri = new Uri(address);
             ContainerHost host = new ContainerHost(new Uri[] { addressUri }, null, addressUri.UserInfo);

--- a/Examples/PeerToPeer/PeerToPeer.Server/Program.cs
+++ b/Examples/PeerToPeer/PeerToPeer.Server/Program.cs
@@ -35,7 +35,7 @@ namespace PeerToPeer.Server
 
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             Uri addressUri = new Uri(address);
             ContainerHost host = new ContainerHost(new Uri[] { addressUri }, null, addressUri.UserInfo);

--- a/Examples/ServiceBus/ServiceBus.Cbs/Program.cs
+++ b/Examples/ServiceBus/ServiceBus.Cbs/Program.cs
@@ -26,7 +26,7 @@ namespace ServiceBus.Cbs
         static void Main(string[] args)
         {
             Trace.TraceLevel = TraceLevel.Information;
-            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             try
             {

--- a/Examples/ServiceBus/ServiceBus.EventHub/Program.cs
+++ b/Examples/ServiceBus/ServiceBus.EventHub/Program.cs
@@ -26,7 +26,7 @@ namespace ServiceBus.EventHub
         static void Main(string[] args)
         {
             Trace.TraceLevel = TraceLevel.Information;
-            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             try
             {

--- a/Examples/ServiceBus/ServiceBus.MessageSession/Program.cs
+++ b/Examples/ServiceBus/ServiceBus.MessageSession/Program.cs
@@ -26,7 +26,7 @@ namespace ServiceBus.MessageSession
         static void Main(string[] args)
         {
             Trace.TraceLevel = TraceLevel.Information;
-            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             try
             {

--- a/Examples/ServiceBus/ServiceBus.Topic/Program.cs
+++ b/Examples/ServiceBus/ServiceBus.Topic/Program.cs
@@ -26,7 +26,7 @@ namespace ServiceBus.Topic
         static void Main(string[] args)
         {
             Trace.TraceLevel = TraceLevel.Information;
-            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 
             try
             {

--- a/articles/tracing.md
+++ b/articles/tracing.md
@@ -11,7 +11,7 @@ To enable tracing, set the trace level and a listener. For example, the followin
 
 ```
 Trace.TraceLevel = TraceLevel.Frame;
-Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
 ```
 
 By implementing the trace listener delegate, you can write the traces to your application's tracing module.

--- a/test/Common/ContainerHostTests.cs
+++ b/test/Common/ContainerHostTests.cs
@@ -50,7 +50,7 @@ namespace Test.Amqp
         static ContainerHostTests()
         {
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
         }
 
         [TestInitialize]

--- a/test/Common/LinkTests.cs
+++ b/test/Common/LinkTests.cs
@@ -47,7 +47,7 @@ namespace Test.Amqp
             Connection.DisableServerCertValidation = true;
             // uncomment the following to write frame traces
             //Trace.TraceLevel = TraceLevel.Frame;
-            //Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+            //Trace.TraceListener = (f, a) => System.Diagnostics.Trace.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
         }
 
 #if NETFX || NETFX35 || NETFX_CORE || DOTNET

--- a/test/PerfTest/Program.cs
+++ b/test/PerfTest/Program.cs
@@ -42,7 +42,7 @@ namespace PerfTest
                 if (perfArgs.TraceLevel != 0)
                 {
                     Trace.TraceLevel = perfArgs.TraceLevel;
-                    Trace.TraceListener = (f, o) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, o));
+                    Trace.TraceListener = (f, o) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, o));
                 }
 
                 Role role;

--- a/test/TestAmqpBroker/Program.cs
+++ b/test/TestAmqpBroker/Program.cs
@@ -123,7 +123,7 @@ namespace TestAmqpBroker
                 }
 
                 Trace.TraceLevel = level;
-                Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:ss.fff]") + " " + string.Format(f, a));
+                Trace.TraceListener = (f, a) => Console.WriteLine(DateTime.Now.ToString("[hh:mm:ss.fff]") + " " + string.Format(f, a));
             }
 
             var broker = new TestAmqpBroker(endpoints, creds, sslValue, queues);


### PR DESCRIPTION
I turned on a trace for a real debugging issue and took a closer look at the time stamp. It used "hh:ss.fff" instead of "hh:mm:ss.fff". Leaving out the minutes creates some crazy trace logs!

The fix seems easy enough.