### PR TITLE
Parameterize link tests to steer AMQP I/O to another broker and path

### DIFF
--- a/test/Common/TestTarget.cs
+++ b/test/Common/TestTarget.cs
@@ -1,0 +1,76 @@
+//  ------------------------------------------------------------------------------------
+//  Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this 
+//  file except in compliance with the License. You may obtain a copy of the License at 
+//  http://www.apache.org/licenses/LICENSE-2.0  
+//  
+//  THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+//  EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR 
+//  CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR 
+//  NON-INFRINGEMENT. 
+// 
+//  See the Apache Version 2.0 License for specific language governing permissions and 
+//  limitations under the License.
+//  ------------------------------------------------------------------------------------
+
+using Amqp;
+using System;
+#if NETFX || NETFX35 || DOTNET
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+#if NETFX_CORE
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#endif
+
+namespace Test.Amqp
+{
+#if NETFX || NETFX35 || NETFX_CORE || DOTNET
+    [TestClass]
+#endif
+
+    /// <summary>
+    /// For self tests that create AMQP connections to a broker
+    /// define the URI of the broker and the name of the queue to use.
+    ///
+    /// The default broker on localhost may be overridden with
+    /// environment variable AMQPNETLITE_TESTTARGET. A single URI
+    /// specifies both the broker (scheme, user, password, host, port)
+    /// and source or target (path) of the broker resource to be
+    /// exercised by the self tests.
+    /// </summary>
+    public class TestTarget
+    {
+        internal const string envVarName = "AMQPNETLITE_TESTTARGET";
+        internal const string defaultAddress = "amqp://guest:guest@localhost:5672/q1";
+        internal string addr;
+        internal string path;
+
+        public TestTarget()
+        {
+            this.addr = Environment.GetEnvironmentVariable(envVarName);
+            if (this.addr == null)
+            {
+                this.addr = defaultAddress;
+            }
+            // Verify that the URI is well formed.
+            Address addr = new Address(this.addr);
+            // Extract the path without the leading "/".
+            path = addr.Path.Substring(1);
+        }
+
+        public string Path
+        {
+            get
+            {
+                return path;
+            }
+        }
+
+        public Address Address
+        {
+            get
+            {
+                return new Address(addr);
+            }
+        }
+    }
+}

--- a/test/Test.Amqp.Net/PerfTests.cs
+++ b/test/Test.Amqp.Net/PerfTests.cs
@@ -25,7 +25,7 @@ namespace Test.Amqp
     [TestClass]
     public class PerfTests
     {
-        Address address = LinkTests.address;
+        TestTarget testTarget = new TestTarget();
 
         [ClassInitialize]
         public static void Initialize(TestContext context)
@@ -45,9 +45,9 @@ namespace Test.Amqp
         public void PerfAtLeastOnceSend()
         {
             string testName = "PerfAtLeastOnceSend";
-            Connection connection = new Connection(address);
+            Connection connection = new Connection(testTarget.Address);
             Session session = new Session(connection);
-            this.sender = new SenderLink(session, "sender-" + testName, "q1");
+            this.sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             this.onOutcome = OnSendComplete;
             this.done = new ManualResetEvent(false);

--- a/test/Test.Amqp.Net/TaskTests.cs
+++ b/test/Test.Amqp.Net/TaskTests.cs
@@ -30,7 +30,7 @@ namespace Test.Amqp
     [TestClass]
     public class TaskTests
     {
-        Address address = LinkTests.address;
+        TestTarget testTarget = new TestTarget();
 
         [ClassInitialize]
         public static void Initialize(TestContext context)
@@ -43,9 +43,9 @@ namespace Test.Amqp
             string testName = "BasicSendReceiveAsync";
             int nMsgs = 100;
 
-            Connection connection = await Connection.Factory.CreateAsync(this.address);
+            Connection connection = await Connection.Factory.CreateAsync(this.testTarget.Address);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             for (int i = 0; i < nMsgs; ++i)
             {
@@ -56,7 +56,7 @@ namespace Test.Amqp
                 await sender.SendAsync(message);
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             for (int i = 0; i < nMsgs; ++i)
             {
                 Message message = await receiver.ReceiveAsync();
@@ -76,9 +76,9 @@ namespace Test.Amqp
         {
             string testName = "CustomMessgeBody";
 
-            Connection connection = await Connection.Factory.CreateAsync(this.address);
+            Connection connection = await Connection.Factory.CreateAsync(this.testTarget.Address);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             Student student = new Student("Tom");
             student.Age = 16;
@@ -89,7 +89,7 @@ namespace Test.Amqp
             message.Properties = new Properties() { MessageId = "student" };
             await sender.SendAsync(message);
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             Message message2 = await receiver.ReceiveAsync();
             Trace.WriteLine(TraceLevel.Information, "receive: {0}", message2.Properties);
             receiver.Accept(message);
@@ -112,9 +112,9 @@ namespace Test.Amqp
             int nMsgs = 50;
 
             Connection connection = await Connection.Factory.CreateAsync(
-                this.address, new Open() { ContainerId = "c1", MaxFrameSize = 4096 }, null);
+                this.testTarget.Address, new Open() { ContainerId = "c1", MaxFrameSize = 4096 }, null);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             int messageSize = 100 * 1024;
             for (int i = 0; i < nMsgs; ++i)
@@ -126,7 +126,7 @@ namespace Test.Amqp
                 await sender.SendAsync(message);
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             for (int i = 0; i < nMsgs; ++i)
             {
                 Message message = await receiver.ReceiveAsync();
@@ -149,9 +149,9 @@ namespace Test.Amqp
             int nMsgs = 50;
 
             Connection connection = await Connection.Factory.CreateAsync(
-                this.address, new Open() { ContainerId = "c1", MaxFrameSize = 4096 }, null);
+                this.testTarget.Address, new Open() { ContainerId = "c1", MaxFrameSize = 4096 }, null);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             int messageSize = 10 * 1024;
             for (int i = 0; i < nMsgs; ++i)
@@ -163,7 +163,7 @@ namespace Test.Amqp
                 sender.Send(message, null, null);
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             ManualResetEvent done = new ManualResetEvent(false);
             int count = 0;
             receiver.Start(30, (link, message) =>
@@ -198,13 +198,13 @@ namespace Test.Amqp
             Address sslAddress = new Address("amqps://guest:guest@127.0.0.1:5671");
             Connection connection = await factory.CreateAsync(sslAddress);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             Message message = new Message("custom transport config");
             message.Properties = new Properties() { MessageId = testName };
             await sender.SendAsync(message);
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             Message message2 = await receiver.ReceiveAsync();
             Assert.IsTrue(message2 != null, "no message received");
             receiver.Accept(message2);

--- a/test/Test.Amqp.Net/Test.Amqp.Net.csproj
+++ b/test/Test.Amqp.Net/Test.Amqp.Net.csproj
@@ -61,6 +61,9 @@
     <Compile Include="..\Common\LinkTests.cs">
       <Link>LinkTests.cs</Link>
     </Compile>
+    <Compile Include="..\Common\TestTarget.cs">
+      <Link>TestTarget.cs</Link>
+    </Compile>
     <Compile Include="..\Common\NamedPipeTransport.cs">
       <Link>NamedPipeTransport.cs</Link>
     </Compile>

--- a/test/Test.Amqp.Net/TransactionTests.cs
+++ b/test/Test.Amqp.Net/TransactionTests.cs
@@ -27,7 +27,7 @@ namespace Test.Amqp
     [TestClass]
     public class TransactionTests
     {
-        Address address = LinkTests.address;
+        TestTarget testTarget = new TestTarget();
 
         [ClassInitialize]
         public static void Initialize(TestContext context)
@@ -43,9 +43,9 @@ namespace Test.Amqp
             string testName = "TransactedPosting";
             int nMsgs = 5;
 
-            Connection connection = new Connection(this.address);
+            Connection connection = new Connection(testTarget.Address);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             // commit
             using (var ts = new TransactionScope())
@@ -84,7 +84,7 @@ namespace Test.Amqp
                 ts.Complete();
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             for (int i = 0; i < nMsgs * 2; i++)
             {
                 Message message = receiver.Receive();
@@ -102,9 +102,9 @@ namespace Test.Amqp
             string testName = "TransactedRetiring";
             int nMsgs = 10;
 
-            Connection connection = new Connection(this.address);
+            Connection connection = new Connection(testTarget.Address);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             // send one extra for validation
             for (int i = 0; i < nMsgs + 1; i++)
@@ -114,7 +114,7 @@ namespace Test.Amqp
                 sender.Send(message);
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
             Message[] messages = new Message[nMsgs];
             for (int i = 0; i < nMsgs; i++)
             {
@@ -179,9 +179,9 @@ namespace Test.Amqp
             string testName = "TransactedRetiringAndPosting";
             int nMsgs = 10;
 
-            Connection connection = new Connection(this.address);
+            Connection connection = new Connection(testTarget.Address);
             Session session = new Session(connection);
-            SenderLink sender = new SenderLink(session, "sender-" + testName, "q1");
+            SenderLink sender = new SenderLink(session, "sender-" + testName, testTarget.Path);
 
             for (int i = 0; i < nMsgs; i++)
             {
@@ -190,7 +190,7 @@ namespace Test.Amqp
                 sender.Send(message);
             }
 
-            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, "q1");
+            ReceiverLink receiver = new ReceiverLink(session, "receiver-" + testName, testTarget.Path);
 
             receiver.SetCredit(2, false);
             Message message1 = receiver.Receive();

--- a/test/Test.Amqp.Net35/Test.Amqp.Net35.csproj
+++ b/test/Test.Amqp.Net35/Test.Amqp.Net35.csproj
@@ -58,6 +58,9 @@
     <Compile Include="..\Common\LinkTests.cs">
       <Link>LinkTests.cs</Link>
     </Compile>
+    <Compile Include="..\Common\TestTarget.cs">
+      <Link>TestTarget.cs</Link>
+    </Compile>
     <Compile Include="..\Common\Types\EmployeeId.cs">
       <Link>Types\EmployeeId.cs</Link>
     </Compile>


### PR DESCRIPTION
Link tests have hard coded "amqp:guest:guest@127.0.0.1:5672" broker
and "q1" path. Changing these to point to another broker/path is a
problem.

This patch creates a TestTarget class that holds the broker
address and path. The default values are the same as before. TestTarget
can override those values with an environment variable in the form of
an Address URI.

  $ SET AMQPNETLITE_TESTTARGET=amqp://admin:password@example.com:9876/bigqueue
  $ mstest ...

Then each test file instantiates an instance of TestTarget and uses
that to locate the broker and what target to use for the test.

This patch has a few outstanding issues:

* I did not see an easy way to provide the override values on the mstest
command line. Good self tests are immune to environment variable settings.
The current solution is a compromise to allow expanded utility in a
simple form. Improvements are welcome.

* Hard coded localhost addresses, ports, and path values of "q1" still exist.
This patch does not try to solve them all.