### PR TITLE
AMQCLIENT-449: Send error output to stderr; errors exit with nonzero …

### DIFF
--- a/Examples/Interop/Interop.Client/Interop.Client.cs
+++ b/Examples/Interop/Interop.Client/Interop.Client.cs
@@ -104,15 +104,15 @@ namespace Examples.Interop
                             }
                             else
                             {
-                                Console.WriteLine("Receiver timeout receiving response {0}", i);
-                                break;
+                                throw new ApplicationException(
+                                    String.Format("Receiver timeout receiving response {0}", i));
                             }
                         }
                     }
                 }
                 else
                 {
-                    Console.WriteLine("Receiver attach timeout");
+                    throw new ApplicationException("Receiver attach timeout");
                 }
                 receiver.Close();
                 sender.Close();
@@ -122,7 +122,7 @@ namespace Examples.Interop
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception {0}.", e);
+                Console.Error.WriteLine("Exception {0}.", e);
                 if (null != connection)
                 {
                     connection.Close();

--- a/Examples/Interop/Interop.Drain/Interop.Drain.cs
+++ b/Examples/Interop/Interop.Drain/Interop.Drain.cs
@@ -73,7 +73,7 @@ namespace Examples.Interop {
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception {0}.", e);
+                Console.Error.WriteLine("Exception {0}.", e);
                 if (null != connection)
                     connection.Close();
                 exitCode = ERROR_OTHER;

--- a/Examples/Interop/Interop.Server/Interop.Server.cs
+++ b/Examples/Interop/Interop.Server/Interop.Server.cs
@@ -83,7 +83,7 @@ namespace Interop.Server
                         }
                         catch (Exception exception)
                         {
-                            Console.WriteLine("Error waiting for response to be sent: {0} exception {1}",
+                            Console.Error.WriteLine("Error waiting for response to be sent: {0} exception {1}",
                                 GetContent(response), exception.Message);
                             break;
                         }
@@ -100,7 +100,7 @@ namespace Interop.Server
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception {0}.", e);
+                Console.Error.WriteLine("Exception {0}.", e);
                 if (null != connection)
                 {
                     connection.Close();

--- a/Examples/Interop/Interop.Spout/Interop.Spout.cs
+++ b/Examples/Interop/Interop.Spout/Interop.Spout.cs
@@ -76,7 +76,7 @@ namespace Examples.Interop {
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception {0}.", e);
+                Console.Error.WriteLine("Exception {0}.", e);
                 if (null != connection)
                     connection.Close();
                 exitCode = ERROR_OTHER;


### PR DESCRIPTION
Automated test environments use the Interop programs and would
benefit from having proper program indications of error vs. normal
operation. This patch adds:

* Error output sent to stderr and not to stdout
* Programs exit with 0 when no error and with >0 when errors.
