### PR TITLE
TCP KeepAlive - Corrected data type and inOptionValues byte allocation

### DIFF
--- a/src/Net/SocketExtensions.cs
+++ b/src/Net/SocketExtensions.cs
@@ -22,7 +22,6 @@ namespace Amqp
     using System.Net;
     using System.Net.Sockets;
     using System.Threading.Tasks;
-    using System.Runtime.InteropServices;
 
     static class SocketExtensions
     {
@@ -35,15 +34,13 @@ namespace Amqp
             ULONG keepaliveinterval;
             };
             */
-
-            ulong keepAliveTime = settings.KeepAliveTime;
-            ulong keepAliveInterval = settings.KeepAliveInterval;
-
-            int bytesPerULong = 8;
+            
+            int bytesPerULong = 4;
             byte[] inOptionValues = new byte[bytesPerULong * 3];
-            BitConverter.GetBytes((ulong)1).CopyTo(inOptionValues, 0);
-            BitConverter.GetBytes(keepAliveTime).CopyTo(inOptionValues, bytesPerULong);
-            BitConverter.GetBytes(keepAliveInterval).CopyTo(inOptionValues, bytesPerULong * 2);
+            
+            BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
+            BitConverter.GetBytes((uint)settings.KeepAliveTime).CopyTo(inOptionValues, bytesPerULong);
+            BitConverter.GetBytes((uint)settings.KeepAliveInterval).CopyTo(inOptionValues, bytesPerULong*2);
 
             socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
         }

--- a/src/Net/SocketExtensions.cs
+++ b/src/Net/SocketExtensions.cs
@@ -33,14 +33,16 @@ namespace Amqp
             ULONG keepalivetime;
             ULONG keepaliveinterval;
             };
+            
+            ULONG is an unsigned 32 bit integer
             */
             
-            int bytesPerULong = 4;
-            byte[] inOptionValues = new byte[bytesPerULong * 3];
+            int bytesPerUInt = 4;
+            byte[] inOptionValues = new byte[bytesPerUInt * 3];
             
             BitConverter.GetBytes((uint)1).CopyTo(inOptionValues, 0);
-            BitConverter.GetBytes((uint)settings.KeepAliveTime).CopyTo(inOptionValues, bytesPerULong);
-            BitConverter.GetBytes((uint)settings.KeepAliveInterval).CopyTo(inOptionValues, bytesPerULong*2);
+            BitConverter.GetBytes((uint)settings.KeepAliveTime).CopyTo(inOptionValues, bytesPerUInt);
+            BitConverter.GetBytes((uint)settings.KeepAliveInterval).CopyTo(inOptionValues, bytesPerUInt * 2);
 
             socket.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
         }

--- a/src/Net/TcpKeepAliveSettings.cs
+++ b/src/Net/TcpKeepAliveSettings.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// How often a keep-alive transmission is sent to an idle connection.
         /// </summary>
-        public ulong KeepAliveTime
+        public uint KeepAliveTime
         {
             get;
             set;
@@ -17,7 +17,7 @@
         /// <summary>
         /// How often a keep-alive transmission is sent when no response is received from previous keep-alive transmissions.
         /// </summary>
-        public ulong KeepAliveInterval
+        public uint KeepAliveInterval
         {
             get;
             set;


### PR DESCRIPTION
While testing I noticed the TCP KeepAlive was not functioning as expected.  After some research I found that 32-bit unsigned integers are expected in the tcp_keepalive struct, rather than 64 bit unsigned integers which were being passed.  With these changes, the TCP Keep-Alive works as expected.