### PR TITLE
Lite-272: Redo computation of receiver link credits

### DIFF
--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -148,6 +148,7 @@ namespace Amqp
         public void SetCredit(int credit, bool autoRestore = true)
         {
             int flowCredit;
+            int dCountSnd;
             lock (this.ThisLock)
             {
                 if (this.IsDetaching)
@@ -157,11 +158,12 @@ namespace Amqp
 
                 this.credit = credit;
                 this.autoRestore = autoRestore;
+                dCountSnd = deliveryCountSnd;
                 flowCredit  = ComputeCredit(deliveryCountRcv, deliveryCountSnd, credit);
                 restoreCountRcv = ComputeRestoreCount(deliveryCountRcv, credit);
                 deliveryLimitSnd = unchecked(deliveryCountRcv + credit);
             }
-            this.SendFlow((uint)this.deliveryCountRcv, (uint)flowCredit, false);
+            this.SendFlow((uint)dCountSnd, (uint)flowCredit, false);
         }
 
         /// <summary>
@@ -410,8 +412,8 @@ namespace Amqp
                 if (autoRestore && credit > 0 && restoreCountRcv == deliveryCountRcv)
                 {
                     issueFlow = true;
-                    flowCredit = ComputeCredit(deliveryCountRcv, deliveryCountSnd, credit);
                     dcSnd = deliveryCountSnd;
+                    flowCredit = ComputeCredit(deliveryCountRcv, dcSnd, credit);
                     restoreCountRcv = ComputeRestoreCount(deliveryCountRcv, credit);
                     deliveryLimitSnd = unchecked(deliveryCountRcv + credit);
                 }

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -156,7 +156,7 @@ namespace Amqp
                 this.credit = credit;
                 this.autoRestore = autoRestore;
                 newCredit  = ComputeCredit(this.deliveryCountRcv, this.deliveryCountSnd, this.credit);
-                this.restoreCountRcv = ComputeRestoreCount(this.deliveryCountSnd, this.credit);
+                this.restoreCountRcv = ComputeRestoreCount(this.deliveryCountRcv, this.credit);
             }
             this.SendFlow((uint)this.deliveryCountRcv, (uint)newCredit, false);
         }


### PR DESCRIPTION
Issue autoRestore flow directives with credit values based on the number of
  messages in flight.
Calling receiver.SetCredit(N) may not result in a flow with a credit
  value of N. The credit value may be less if more messages have been
  received and have not yet received a disposition.
Credit is only issued by the library if autoRestore is true. Previously
  the library may have issued Flows with credit in error.