### PR TITLE
Lite-272: Rework ReceiverLink credit processing

### DIFF
--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -32,11 +32,17 @@ namespace Amqp
 #else
         const int DefaultCredit = 20;
 #endif
-        // flow control
-        SequenceNumber deliveryCount;
-        int totalCredit;
+        const int CREDIT_NOT_SET = -1;
+
+        // flow control - user controlled settings
         int credit;
-        int restored;
+        bool autoRestore;
+        // flow control - messages-in-flight tracking
+        SequenceNumber deliveryCountSnd;  // sender's sequence of next message to be received
+        SequenceNumber deliveryCountRcv;  // receiver's sequence of messages disposed
+        // flow control - event thresholds
+        SequenceNumber restoreCountRcv;   // receiver's sequence that triggers autoRestore
+        SequenceNumber overrunLimitSnd;   // sender's sequence that constitutes credit overrun
 
         // received messages queue
         LinkedList receivedMessages;
@@ -79,7 +85,12 @@ namespace Amqp
         public ReceiverLink(Session session, string name, Attach attach, OnAttached onAttached)
             : base(session, name, onAttached)
         {
-            this.totalCredit = -1;
+            this.credit = CREDIT_NOT_SET;
+            this.autoRestore = true;
+            this.deliveryCountSnd = 0;
+            this.deliveryCountRcv = 0;
+            this.restoreCountRcv = 0;
+            this.overrunLimitSnd = 0;
             this.receivedMessages = new LinkedList();
             this.waiterList = new LinkedList();
             this.SendAttach(true, 0, attach);
@@ -98,14 +109,50 @@ namespace Amqp
         }
 
         /// <summary>
-        /// Sets a credit on the link. A flow is sent to the peer to update link flow control state.
+        /// Computes amount of credit to issue in a Flow based on desired credit and
+        /// numbers of messages in flight. Will not return negative credit.
+        /// </summary>
+        /// <param name="count_rcv">reciever delivery count</param>
+        /// <param name="count_snd">sender deliver count</param>
+        /// <param name="credit">desirec message credit</param>
+        /// <returns></returns>
+        internal int ComputeFlowCredit(uint count_rcv, uint count_snd, int credit)
+        {
+            uint rCredit = unchecked(count_rcv + (uint)credit - count_snd);
+            int iCredit = (int)rCredit;
+            if (iCredit < 0) iCredit = 0;
+            return iCredit;
+        }
+
+        /// <summary>
+        /// Compute receive delivery count at which autoRestore will
+        /// issue a new credit flow.
+        /// </summary>
+        /// <param name="count_rcv">receiver delivery count</param>
+        /// <param name="credit">credit setting</param>
+        /// <returns></returns>
+        internal uint ComputeRestoreCount(SequenceNumber count_rcv, int credit)
+        {
+            uint rCount = unchecked(count_rcv + (((uint)credit + 1) / 2));
+            return rCount;
+        }
+
+        /// <summary>
+        /// Sets a credit on the link. 
+        ///  * A flow is sent to the peer to update link flow control state.
+        ///  * Sender's credit overrun limit is recalculated.
+        ///  * Receiver's credit autoRestore point is recalcaulted.
         /// </summary>
         /// <param name="credit">The new link credit.</param>
-        /// <param name="autoRestore">If true, link credit is auto-restored when a message is accepted
-        /// or rejected by the caller. If false, caller is responsible for manage link credits.</param>
+        /// <param name="autoRestore"> If false, caller is responsible for
+        /// managing link credit. If true, link credit is auto-restored when
+        /// a message is disposed (Accept, Reject, Modified, Released) by the caller
+        /// and the receiver has disposed of enough messages so that a new credit of at least
+        /// credit/2 may be issued.</param>
         public void SetCredit(int credit, bool autoRestore = true)
         {
-            uint dc;
+            int flowCredit;
+            uint dcSnd;
             lock (this.ThisLock)
             {
                 if (this.IsDetaching)
@@ -113,13 +160,14 @@ namespace Amqp
                     return;
                 }
 
-                this.totalCredit = autoRestore ? credit : 0;
                 this.credit = credit;
-                this.restored = 0;
-                dc = this.deliveryCount;
+                this.autoRestore = autoRestore;
+                dcSnd = deliveryCountSnd;
+                flowCredit  = ComputeFlowCredit(deliveryCountRcv, dcSnd, credit);
+                restoreCountRcv = ComputeRestoreCount(deliveryCountRcv, credit);
+                overrunLimitSnd = unchecked(deliveryCountRcv + credit);
             }
-
-            this.SendFlow(dc, (uint)credit, false);
+            this.SendFlow(dcSnd, (uint)flowCredit, false);
         }
 
         /// <summary>
@@ -213,6 +261,15 @@ namespace Amqp
 
             if (!transfer.More)
             {
+                lock (ThisLock)
+                {
+                    if (deliveryCountSnd > overrunLimitSnd)
+                    {
+                        throw new AmqpException(ErrorCode.TransferLimitExceeded,
+                            Fx.Format(SRAmqp.DeliveryLimitExceeded, transfer.DeliveryId));
+                    }
+                    deliveryCountSnd++; // message has arrived
+                }
                 this.deliveryCurrent = null;
                 delivery.Message = Message.Decode(delivery.Buffer);
 
@@ -267,7 +324,8 @@ namespace Amqp
         internal override void OnAttach(uint remoteHandle, Attach attach)
         {
             base.OnAttach(remoteHandle, attach);
-            this.deliveryCount = attach.InitialDeliveryCount;
+            deliveryCountSnd = deliveryCountRcv = attach.InitialDeliveryCount;
+            this.overrunLimitSnd = unchecked(deliveryCountSnd + credit);
         }
 
         internal override void OnDeliveryStateChanged(Delivery delivery)
@@ -330,7 +388,7 @@ namespace Amqp
             }
 
             // send credit after waiter creation to avoid race condition
-            if (this.totalCredit < 0)
+            if (this.credit == CREDIT_NOT_SET)
             {
                 this.SetCredit(DefaultCredit, true);
             }
@@ -351,10 +409,24 @@ namespace Amqp
         void DisposeMessage(Message message, Outcome outcome)
         {
             Delivery delivery = message.Delivery;
-            if (this.totalCredit > 0 &&
-            Interlocked.Increment(ref this.restored) >= (this.totalCredit / 2))
+            bool issueFlow = false;
+            int flowCredit = 0;
+            uint dcSnd = 0;
+            lock (ThisLock)
             {
-                this.SetCredit(this.totalCredit, true);
+                deliveryCountRcv++;
+                if (autoRestore && credit > 0 && restoreCountRcv == deliveryCountRcv)
+                {
+                    issueFlow = true;
+                    dcSnd = deliveryCountSnd;
+                    flowCredit = ComputeFlowCredit(deliveryCountRcv, dcSnd, credit);
+                    restoreCountRcv = ComputeRestoreCount(deliveryCountRcv, credit);
+                    overrunLimitSnd = unchecked(deliveryCountRcv + credit);
+                }
+            }
+            if (issueFlow)
+            {
+                this.SendFlow(dcSnd, (uint)flowCredit, false);
             }
             if (delivery == null || delivery.Settled)
             {
@@ -378,14 +450,6 @@ namespace Amqp
         void OnDelivery(SequenceNumber deliveryId)
         {
             // called with lock held
-            if (this.credit <= 0)
-            {
-                throw new AmqpException(ErrorCode.TransferLimitExceeded,
-                    Fx.Format(SRAmqp.DeliveryLimitExceeded, deliveryId));
-            }
-
-            this.deliveryCount++;
-            this.credit--;
         }
 
         sealed class MessageNode : INode


### PR DESCRIPTION
Send sequence and receive sequence events are counted to track in-flight messages.
Credit to be sent in Flow messages is based on target credit and in-flight numbers.
Credit autoRefresh happens when receiver has processed credit/2 messages.