### PR TITLE
Fix typos in (doc)comments

### DIFF
--- a/Examples/Device/Device.Controller2/MainPage.xaml.cs
+++ b/Examples/Device/Device.Controller2/MainPage.xaml.cs
@@ -32,7 +32,7 @@ namespace Device.Controller
     /// to the phone).
     /// The app works with the test broker. Start it as follows:
     ///   TestAmqpBroker.exe amqp://localhost:5672 /creds:guest:guest
-    /// Add "/trace:frame" to output frames for debugging if requried.
+    /// Add "/trace:frame" to output frames for debugging if required.
     /// </summary>
     public sealed partial class MainPage : Page
     {

--- a/Examples/Device/Device.Thermometer/Program.cs
+++ b/Examples/Device/Device.Thermometer/Program.cs
@@ -26,13 +26,13 @@ using AmqpTrace = Amqp.Trace;
 
 namespace Device.Thermometer
 {
-    /// The thermomeer runs on NETMF. It displays a number for the current
-    /// temprature. Click up and down buttons to increase/decrease the number.
+    /// The thermometer runs on NETMF. It displays a number for the current
+    /// temperature. Click up and down buttons to increase/decrease the number.
     /// Ensure the broker is running and change the host name below.
     /// If using "amqps", ensure SSL is working on the device.
     /// The app works with the test broker. Start it as follows:
     ///   TestAmqpBroker.exe amqp://localhost:5672 /creds:guest:guest
-    /// Add "/trace:frame" to output frames for debugging if requried.
+    /// Add "/trace:frame" to output frames for debugging if required.
     public class Program : Application
     {
         string address = "amqp://guest:guest@localhost:5672";
@@ -58,7 +58,7 @@ namespace Device.Thermometer
 
         private void Listen()
         {
-            // real applicaiton needs to implement error handling and recovery
+            // real application needs to implement error handling and recovery
             Connection connection = new Connection(new Address(this.address));
             Session session = new Session(connection);
             SenderLink sender = new SenderLink(session, "send-link", "data");

--- a/Examples/Reconnect/ReconnectSender/ReconnectSender.cs
+++ b/Examples/Reconnect/ReconnectSender/ReconnectSender.cs
@@ -14,9 +14,9 @@
 
 //
 // ReconnectSender 
-//  * Detects a failed AMQP connection and automatically reconnets it.
+//  * Detects a failed AMQP connection and automatically reconnects it.
 //  * Recovers from a peer failure by connecting to a list of AMQP brokers/peers.
-//  * Builds or rebuilds the AMPQ object hierarchy in response to protocol events.
+//  * Builds or rebuilds the AMQP object hierarchy in response to protocol events.
 //  * Recovers from all failures by reconnecting the AMQP connection.
 //
 // Command line:

--- a/Examples/ServiceBus/Scenarios/MessageSessionExample.cs
+++ b/Examples/ServiceBus/Scenarios/MessageSessionExample.cs
@@ -34,7 +34,7 @@ namespace ServiceBus.Scenarios
         {
             string[] priorites = new string[] { "low", "medium", "high" };
 
-            // send messages with differnt session IDs
+            // send messages with different session IDs
             this.SendMessages(100, priorites);
 
             // receive messages from a specific session

--- a/Examples/ServiceBus/Scenarios/TopicExample.cs
+++ b/Examples/ServiceBus/Scenarios/TopicExample.cs
@@ -23,7 +23,7 @@ namespace ServiceBus.Scenarios
     using Amqp.Framing;
 
     /// <summary>
-    /// This example assumes a topic and a subscirption named "sub1" is precreated.
+    /// This example assumes a topic and a subscription named "sub1" is precreated.
     /// Example.Entity should be set to the topic name.
     /// </summary>
     class TopicExample : Example

--- a/netmf/NetMFLite/Client.cs
+++ b/netmf/NetMFLite/Client.cs
@@ -553,7 +553,7 @@ namespace Amqp
                     }
                     break;
                 }
-                case 0x16ul:  // dettach
+                case 0x16ul:  // detach
                 {
                     Fx.DebugPrint(false, channel, "detach", fields, "handle");
                     Link link = this.links[(uint)fields[0]];
@@ -678,7 +678,7 @@ namespace Amqp
         {
             byte[] headerBuffer = this.ReadFixedSizeBuffer(8);
             int size = AmqpBitConverter.ReadInt(headerBuffer, 0);
-            frameType = headerBuffer[5];    // TOOD: header EXT
+            frameType = headerBuffer[5];    // TODO: header EXT
             channel = (ushort)(headerBuffer[6] << 8 | headerBuffer[7]);
 
             size -= 8;

--- a/src/Framing/Codec.cs
+++ b/src/Framing/Codec.cs
@@ -127,7 +127,7 @@ namespace Amqp.Framing
 
         // Transport layer should call Codec to encode/decode frames. It ensures that
         // all dependant static fields in other class are initialized correctly.
-        // NETMF does not track cross-class static field/ctor dependancies
+        // NETMF does not track cross-class static field/ctor dependencies
 
         public static void Encode(RestrictedDescribed command, ByteBuffer buffer)
         {

--- a/src/Framing/Properties.cs
+++ b/src/Framing/Properties.cs
@@ -163,7 +163,7 @@ namespace Amqp.Framing
         /// <summary>
         /// Gets the message identifier.
         /// </summary>
-        /// <returns>An object represending the message identifier. null if
+        /// <returns>An object representing the message identifier. null if
         /// it is not set.</returns>
         public object GetMessageId()
         {
@@ -183,7 +183,7 @@ namespace Amqp.Framing
         /// <summary>
         /// Gets the correlation identifier.
         /// </summary>
-        /// <returns>An object represending the message identifier. null if
+        /// <returns>An object representing the message identifier. null if
         /// it is not set.</returns>
         public object GetCorrelationId()
         {

--- a/src/IAmqpObject.cs
+++ b/src/IAmqpObject.cs
@@ -52,7 +52,7 @@ namespace Amqp
     /// <summary>
     /// A callback that is invoked when an outcome is received from peer for a message.
     /// </summary>
-    /// <param name="sender">The link where the message is transfered.</param>
+    /// <param name="sender">The link where the message is transferred.</param>
     /// <param name="message">The message to which the outcome applies.</param>
     /// <param name="outcome">The received outcome from the remote peer.</param>
     /// <param name="state">The user object specified in the Send method.</param>
@@ -117,7 +117,7 @@ namespace Amqp
     public partial interface IConnection : IAmqpObject
     {
         /// <summary>
-        /// Creates a session in the connectioin.
+        /// Creates a session in the connection.
         /// </summary>
         /// <returns>An ISession object.</returns>
         ISession CreateSession();

--- a/src/Listener/ConnectionListener.cs
+++ b/src/Listener/ConnectionListener.cs
@@ -34,7 +34,7 @@ namespace Amqp.Listener
     using Amqp.Types;
 
     /// <summary>
-    /// The conneciton listener accepts AMQP connections from an address.
+    /// The connection listener accepts AMQP connections from an address.
     /// </summary>
     public class ConnectionListener : ConnectionFactoryBase
     {

--- a/src/Listener/ContainerHost.cs
+++ b/src/Listener/ContainerHost.cs
@@ -51,14 +51,14 @@ namespace Amqp.Listener
     ///    to handle all link events (flow, transfer and disposition). However, it
     ///    is recommended to use the built-in LinkEndpoint classes.
     ///  * TargetLinkEndpoint: a TargetLinkEndpoint simply forwards the request
-    ///    to the IMessgeProcessor.
+    ///    to the IMessageProcessor.
     ///  * SourceLinkEndpoint: a SourceLinkEndpoint manages link credit and
     ///    transforms flow state into a receive loop on the IMessageSource. Delivery
     ///    acknowledgements are simply forwarded to the IMessageSource.
     /// 
     /// When per-link handling is required, it is recommended to combine message
     /// level processing with link level processing.
-    ///  * An IMessageProcessor/Souce should be implemented.
+    ///  * An IMessageProcessor/Source should be implemented.
     ///  * After the link attach is handled, wrap it in a Target/SourceLinkEndpoint
     ///    that works with the previously implemented message processor or source.
     ///
@@ -66,7 +66,7 @@ namespace Amqp.Listener
     /// processors (IMessageProcessor, IMessageSource, IRequestProcessor) are
     /// checked first. If a processor matches the address on the received attach
     /// performative, a link is automatically created and the send/receive requests
-    /// will be rounted to the associated processor.
+    /// will be routed to the associated processor.
     /// Otherwise, the registered link processor, if any, is invoked to create a
     /// LinkEndpoint, where subsequent send/receive requests will be routed.
     /// When none is found, the link is detached with error "amqp:not-found".

--- a/src/Listener/Context.cs
+++ b/src/Listener/Context.cs
@@ -58,7 +58,7 @@ namespace Amqp.Listener
         }
 
         /// <summary>
-        /// Gets the state of the concext.
+        /// Gets the state of the context.
         /// </summary>
         public ContextState State
         {

--- a/src/Listener/ContextState.cs
+++ b/src/Listener/ContextState.cs
@@ -18,7 +18,7 @@
 namespace Amqp.Listener
 {
     /// <summary>
-    /// The state of a concext.
+    /// The state of a context.
     /// </summary>
     public enum ContextState
     {

--- a/src/Listener/TargetLinkEndpoint.cs
+++ b/src/Listener/TargetLinkEndpoint.cs
@@ -40,7 +40,7 @@ namespace Amqp.Listener
         }
 
         /// <summary>
-        /// Notifies the message processor to processe a received message.
+        /// Notifies the message processor to process a received message.
         /// </summary>
         /// <param name="messageContext">Context of the received message.</param>
         public override void OnMessage(MessageContext messageContext)

--- a/src/Net/BufferManager.cs
+++ b/src/Net/BufferManager.cs
@@ -40,7 +40,7 @@ namespace Amqp
         /// </summary>
         /// <param name="minBufferSize">The minimum size in bytes of pooled buffers.</param>
         /// <param name="maxBufferSize">The maximum size in bytes of pooled buffers.</param>
-        /// <param name="maxMemorySize">The maximum totoal size in bytes of pooled buffers.</param>
+        /// <param name="maxMemorySize">The maximum total size in bytes of pooled buffers.</param>
         public BufferManager(int minBufferSize, int maxBufferSize, long maxMemorySize)
         {
             CheckBufferSize(minBufferSize, "minBufferSize");

--- a/src/Serialization/AmqpContractAttribute.cs
+++ b/src/Serialization/AmqpContractAttribute.cs
@@ -42,7 +42,7 @@ namespace Amqp.Serialization
     /// attribute determines the relative positions of the members in the list. Duplicate
     /// Order values are not allowed. If the class is derived from a base class, the
     /// AmqpMember fields/properties of the base class, if any, are also included in the list.
-    /// The list is flatterned.
+    /// The list is flattened.
     /// Map: the value is encoded as an AMQP map that contains all fields/properties of
     /// the class decorated with AmqpMemberAttribute. The key type is AMQP symbol. The key
     /// values are determined by the Name property of each AmqpMember attribute. If the class

--- a/src/Serialization/AmqpContractResolver.cs
+++ b/src/Serialization/AmqpContractResolver.cs
@@ -183,7 +183,7 @@ namespace Amqp.Serialization
         }
 
         /// <summary>
-        /// Called when a type is successully resolved. Derived class can
+        /// Called when a type is successfully resolved. Derived class can
         /// override this method to update the contract if necessary.
         /// </summary>
         /// <param name="contract">The serialization contract.</param>

--- a/src/Serialization/AmqpSerializer.cs
+++ b/src/Serialization/AmqpSerializer.cs
@@ -28,7 +28,7 @@ namespace Amqp.Serialization
     /// <summary>
     /// Serializes and deserializes an instance of an AMQP type.
     /// The descriptor (name and code) is scoped to and must be
-    /// uniqueue within an instance of the serializer.
+    /// unique within an instance of the serializer.
     /// When the static Serialize and Deserialize methods are called,
     /// the default instance is used.
     /// </summary>

--- a/src/Serialization/SerializableType.cs
+++ b/src/Serialization/SerializableType.cs
@@ -335,7 +335,7 @@ namespace Amqp.Serialization
 
                     if (count > 0)
                     {
-                        // skip unknow members
+                        // skip unknown members
                         buffer.Complete(size - (buffer.Offset - offset) - encodeWidth);
                     }
                 }

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -23,7 +23,7 @@ namespace Amqp.Types
     using System.Globalization;
 
     /// <summary>
-    /// The delegate to create a decribed object.
+    /// The delegate to create a described object.
     /// </summary>
     /// <returns></returns>
     public delegate Described CreateDescribed();

--- a/test/Common/AmqpSerializerTests.cs
+++ b/test/Common/AmqpSerializerTests.cs
@@ -632,7 +632,7 @@ namespace Test.Amqp
             inputMessage.ApplicationProperties["p2"] = 5ul;
             ByteBuffer buffer = inputMessage.Encode();
 
-            // decode the message in a new app domain to ensure codec is intialized
+            // decode the message in a new app domain to ensure codec is initialized
             AppDomain ad = AppDomain.CreateDomain(
                 "test-app-domain",
                 AppDomain.CurrentDomain.Evidence,
@@ -744,7 +744,7 @@ namespace Test.Amqp
         static void MessageBodyTest<T>(T value, Action<T, T> validator)
         {
 #if DOTNET
-            // on .Net Core, serializer is in seperated package
+            // on .Net Core, serializer is in separated package
             // the generic AmqpValue<T> must be used to support custom types
             var inputMessage = new Message() { BodySection = new AmqpValue<T>(value) };
 #else

--- a/test/Common/TestListener.cs
+++ b/test/Common/TestListener.cs
@@ -273,7 +273,7 @@ namespace Test.Amqp
                     }
                     break;
 
-                case 0x16ul:  // dettach
+                case 0x16ul:  // detach
                     if (this.HandleTestPoint(TestPoint.Detach, stream, channel, fields) == TestOutcome.Continue)
                     {
                         FRM(stream, 0x16UL, 0, channel, fields[0], true);

--- a/test/Common/TestTarget.cs
+++ b/test/Common/TestTarget.cs
@@ -23,7 +23,7 @@ namespace Test.Amqp
     ///
     /// The default broker on localhost may be overridden with
     /// environment variable AMQPNETLITE_TESTTARGET. A single URI
-    /// specifies both the broker (scheme, user, password, host, port)
+    /// specifies both the broker (scheme, user, password, host, porte
     /// and source or target (path) of the broker resource to be
     /// exercised by the self tests.
     /// </summary>


### PR DESCRIPTION
Besides what I've noticed myself in ReconnectSender.cs example,
all credit belongs to the spellchecker.