### PR TITLE
Fix float array serialization

### DIFF
--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -156,6 +156,7 @@ namespace Amqp.Types
                 // 10: float
                 new Serializer()
                 {
+                    Type = typeof(float),
                     Encoder = delegate(ByteBuffer b, object o, bool s) { WriteFloat(b, (float)o); },
                     Decoder = delegate(ByteBuffer b, byte c) { return ReadFloat(b, c); }
                 },


### PR DESCRIPTION
Fixes the 
````
Value cannot be null.
Parameter name: elementType
````
exception when serializing float arrays.