### PR TITLE
Update nanoframework projects and nuspecs

### DIFF
--- a/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
@@ -25,14 +25,14 @@
     <ProjectReference Include="..\..\..\nanoFramework\Amqp.Micro.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.0.4\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.6.21, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.0.6-preview-021\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.4" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.6-preview-021" targetFramework="netnanoframework10" />
 </packages>

--- a/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
+++ b/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
@@ -25,18 +25,18 @@
     <ProjectReference Include="..\..\..\nanoFramework\Amqp.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.0.4\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.6.21, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.0.6-preview-021\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.0.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.0.2-preview-023\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="Windows.Devices.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Windows.Devices.Gpio.1.0.0\lib\Windows.Devices.Gpio.dll</HintPath>
+    <Reference Include="Windows.Devices.Gpio, Version=1.0.2.25, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Windows.Devices.Gpio.1.0.2-preview-025\lib\Windows.Devices.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/Examples/Device/Device.Thermometer.nanoFramework/packages.config
+++ b/Examples/Device/Device.Thermometer.nanoFramework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.6-preview-021" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.2-preview-023" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Windows.Devices.Gpio" version="1.0.2-preview-025" targetFramework="netnanoframework10" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ AMQP.Net Lite is a lightweight AMQP 1.0 library for the .Net Framework, .Net Cor
 |AMQPNetLite.WebSockets (.Net Core)|[![NuGet Version and Downloads count](https://buildstats.info/nuget/AMQPNetLite.WebSockets?includePreReleases=true)](https://www.nuget.org/packages/AMQPNetLite.WebSockets/)|
 |AMQPNetLite.NetMF (NETMF)|[![NuGet Version and Downloads count](https://buildstats.info/nuget/AMQPNetLite.NetMF)](https://www.nuget.org/packages/AMQPNetLite.NetMF/)|
 |AMQPNetMicro (NETMF)|[![NuGet Version and Downloads count](https://buildstats.info/nuget/AMQPNetMicro)](https://www.nuget.org/packages/AMQPNetMicro/)|
-|AMQPNetLite.nanoFramework (nanoFramework)||
-|AMQPNetMicro.nanoFramework (nanoFramework)||
+|AMQPNetLite.nanoFramework (nanoFramework)|[![NuGet Version and Downloads count](https://buildstats.info/nuget/AMQPNetLite.nanoFramework?includePreReleases=true)](https://www.nuget.org/packages/AMQPNetLite.nanoFramework/)|
+|AMQPNetMicro.nanoFramework (nanoFramework)|[![NuGet Version and Downloads count](https://buildstats.info/nuget/AMQPNetMicro.nanoFramework?includePreReleases=true)](https://www.nuget.org/packages/AMQPNetMicro.nanoFramework/)|
 
 ## Features
 * Full control of AMQP 1.0 protocol behavior.

--- a/nanoFramework/Amqp.Micro.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.Micro.nanoFramework.nfproj
@@ -104,23 +104,28 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.4\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.6.21, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.6-preview-021\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.2-preview-023\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Native.1.0.0\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.0.2.16, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.0.2-preview-016\lib\nanoFramework.Runtime.Native.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.0.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Math, Version=1.0.2.15, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.0.2-preview-015\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Net, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.0.2-preview-023\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/nanoFramework/Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.nanoFramework.nfproj
@@ -293,23 +293,28 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.4\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.0.6.21, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.6-preview-021\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.2-preview-023\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Native.1.0.0\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.0.2.16, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Native.1.0.2-preview-016\lib\nanoFramework.Runtime.Native.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.0.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Math, Version=1.0.2.15, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.0.2-preview-015\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Net, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.0.2-preview-023\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/nanoFramework/Test.Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Test.Amqp.nanoFramework.nfproj
@@ -31,32 +31,27 @@
     <ProjectReference Include="Amqp.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.0.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.4\lib\mscorlib.dll</HintPath>
+    <Folder Include="Test\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.0.6.21, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.0.6-preview-021\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.2-preview-023\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Native.1.0.0\lib\nanoFramework.Runtime.Native.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
-    </Reference>
-    <Reference Include="System.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.0.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.0.2.23, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.0.2-preview-023\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Test\" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/nanoFramework/packages.config
+++ b/nanoFramework/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.0.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.0.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.0.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.0.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.0.6-preview-021" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.0.2-preview-023" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.0.2-preview-016" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.0.2-preview-015" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.0.2-preview-023" targetFramework="netnanoframework10" />
 </packages>

--- a/nuspec/AMQPNetLite.nanoFramework.nuspec
+++ b/nuspec/AMQPNetLite.nanoFramework.nuspec
@@ -5,6 +5,7 @@
     <title>AMQP.Net Lite for nanoFramework</title>
     <version>0.0.0</version>
     <authors>xinchen</authors>
+    <owners>Microsoft</owners>
     <licenseUrl>https://github.com/Azure/amqpnetlite/blob/master/license.txt</licenseUrl>
     <projectUrl>https://github.com/Azure/amqpnetlite</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -17,12 +18,11 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP net netmf nf nanoframework</tags>
     <dependencies>
-      <group targetFramework="netnanoframework10">
-        <dependency id="nanoFramework.CoreLibrary" version="1.0.0-preview073" />
-        <dependency id="nanoFramework.Runtime.Events" version="1.0.0-preview188" />
-        <dependency id="nanoFramework.Runtime.Native" version="1.0.0-preview194" />
-        <dependency id="nanoFramework.System.Net" version="1.0.0-preview047" />
-      </group>
+      <dependency id="nanoFramework.CoreLibrary" version="1.0.6-preview-021" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.0.2-preview-023" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.0.2-preview-016" />
+      <dependency id="nanoFramework.System.Math" version="1.0.2-preview-015" />
+      <dependency id="nanoFramework.System.Net" version="1.0.2-preview-023" />
     </dependencies>
   </metadata>
   <files>

--- a/nuspec/AMQPNetMicro.nanoFramework.nuspec
+++ b/nuspec/AMQPNetMicro.nanoFramework.nuspec
@@ -14,12 +14,11 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP netmf nf nanoframework</tags>
     <dependencies>
-      <group targetFramework="netnanoframework10">
-        <dependency id="nanoFramework.CoreLibrary" version="1.0.0-preview073" />
-        <dependency id="nanoFramework.Runtime.Events" version="1.0.0-preview188" />
-        <dependency id="nanoFramework.Runtime.Native" version="1.0.0-preview194" />
-        <dependency id="nanoFramework.System.Net" version="1.0.0-preview047" />
-      </group>
+      <dependency id="nanoFramework.CoreLibrary" version="1.0.6-preview-021" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.0.2-preview-023" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.0.2-preview-016" />
+      <dependency id="nanoFramework.System.Math" version="1.0.2-preview-015" />
+      <dependency id="nanoFramework.System.Net" version="1.0.2-preview-023" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
- Remove target framework from nuspecs dependency group because this is not an officilly supported framework ID and nuget is not able to package it using it.
- Add missing owner to the nuspec.
- Add NuGet badges to readme.
- Update NuGets to latest available.