### PR TITLE
 Allow credit auto-restore threshold to be specified by the application

### DIFF
--- a/src/IAmqpObject.cs
+++ b/src/IAmqpObject.cs
@@ -235,6 +235,14 @@ namespace Amqp
         /// or rejected by the caller. If false, caller is responsible for manage link credits.</param>
         void SetCredit(int credit, bool autoRestore);
 
+		/// <summary>
+        /// Sets a credit on the link. It is the total number of unacknowledged messages the remote peer can send.
+        /// </summary>
+        /// <param name="credit">The new link credit.</param>
+        /// <param name="autoRestoreThreshold">The number of messages accepted or rejected by the caller,
+        /// after which link credit is auto-restored.</param>
+        void SetCredit(int credit, int autoRestoreThreshold);
+
         /// <summary>
         /// Receives a message. The call is blocked until a message is available or after a default wait time.
         /// </summary>

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -123,7 +123,7 @@ namespace Amqp
                 throw new ArgumentOutOfRangeException(nameof(credit));
             }
 
-            SetCredit(credit, autoRestore, autoRestore ? credit / 2 : 0); 
+            this.SetCredit(credit, autoRestore, autoRestore ? credit / 2 : 0); 
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace Amqp
                 throw new ArgumentOutOfRangeException(nameof(autoRestoreThreshold));
             }
 
-            SetCredit(credit, true, autoRestoreThreshold);
+            this.SetCredit(credit, true, autoRestoreThreshold);
         }
 
         void SetCredit(int credit, bool autoRestore, int autoRestoreThreshold)

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -34,12 +34,12 @@ namespace Amqp
 #endif
         // flow control
         SequenceNumber deliveryCount;
-        int totalCredit;			// total credit set by app or the default
-        bool autoRestore;			// auto flow credit
-        int autoRestoreThreshold;	// the number of messages processed before credit is auto-restored
-        int pending;				// queued or being processed by application
-        int credit;					// remaining credit
-        int restored;				// processed by the application
+        int totalCredit;          // total credit set by app or the default
+        bool autoRestore;         // auto flow credit
+        int autoRestoreThreshold; // the number of messages processed before credit is auto-restored
+        int pending;              // queued or being processed by application
+        int credit;               // remaining credit
+        int restored;             // processed by the application
 
         // received messages queue
         LinkedList receivedMessages;

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -139,7 +139,7 @@ namespace Amqp
                 throw new ArgumentOutOfRangeException(nameof(credit));
             }
 
-            if (autoRestoreThreshold < 0 || autoRestoreThreshold > this.credit)
+            if (autoRestoreThreshold < 0 || autoRestoreThreshold > credit)
             {
                 throw new ArgumentOutOfRangeException(nameof(autoRestoreThreshold));
             }

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -118,7 +118,7 @@ namespace Amqp
         /// </remarks>
         public void SetCredit(int credit, bool autoRestore = true)
         {
-           if (credit < 0)
+            if (credit < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(credit));
             }


### PR DESCRIPTION
Added a SetCredit overload to the ReceiverLink class to allow the credit auto-restore threshold to be specified by the application.