### PR TITLE
Optimization for String Encoding/Decoding

### DIFF
--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -730,7 +730,7 @@ namespace Amqp.Types
                     buffer.ValidateWrite(byteCount);
                     fixed (byte* bytes = buffer.Buffer)
                     {
-                        Encoding.UTF8.GetBytes(chars, value.Length, bytes + buffer.Offset, byteCount);
+                        Encoding.UTF8.GetBytes(chars, value.Length, bytes + buffer.WritePos, byteCount);
                         buffer.Append(byteCount);
                     }
                 }
@@ -1531,7 +1531,7 @@ namespace Amqp.Types
                     fixed (byte* bytes = buffer.Buffer)
                     {
                         Encoding.UTF8.GetChars(bytes + buffer.Offset, count, chars, charCount);
-                        value = new string(chars);
+                        value = new string(chars, 0, charCount);
                     }
                 }
             }

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -63,7 +63,7 @@ namespace Amqp.Types
         const long epochTicks = 621355968000000000; // 1970-1-1 00:00:00 UTC
 #endif
         internal const long TicksPerMillisecond = 10000;
-#if !NETMF
+#if !NETMF && !NETFX_CORE
         private const int MaxBytesForStackalloc = 512;
 #endif
         static Serializer[] serializers;
@@ -697,7 +697,7 @@ namespace Amqp.Types
             }
             else
             {
-#if NETMF
+#if NETMF || NETFX_CORE
                 byte[] data = Encoding.UTF8.GetBytes(value);
                 if (smallEncoding && data.Length <= byte.MaxValue)
                 {
@@ -1514,7 +1514,7 @@ namespace Amqp.Types
                        
             buffer.ValidateRead(count);
 
-#if NETMF
+#if NETMF || NETFX_CORE
             string value = new string(Encoding.UTF8.GetChars(buffer.Buffer, buffer.Offset, count));
 #else
             string value;


### PR DESCRIPTION
These are two optimizations for String Encoding and Decoding.

The first one for encoding strings avoids the allocation of a temporary byte[] in Encoder.WriteString() by using the unsafe Encoding overload that can write directly int the target ByteBuffer. This is a clear improvement, being both faster and with less allocations.

```
          Method | StringLength |        Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
---------------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 WriteString_Old |            1 |    78.83 ns | 0.8396 ns | 0.7853 ns |      0.0101 |           - |           - |                16 B |
 WriteString_New |            1 |    38.84 ns | 0.5957 ns | 0.4975 ns |           - |           - |           - |                   - |
 WriteString_Old |          128 |   253.62 ns | 1.9966 ns | 1.8676 ns |      0.0887 |           - |           - |               140 B |
 WriteString_New |          128 |   193.85 ns | 0.9445 ns | 0.8834 ns |           - |           - |           - |                   - |
 WriteString_Old |         1024 | 1,435.21 ns | 9.5629 ns | 8.9452 ns |      0.6580 |           - |           - |              1036 B |
 WriteString_New |         1024 | 1,263.09 ns | 6.6658 ns | 6.2352 ns |           - |           - |           - |                   - |
```
The second one for decoding strings avoids the temporary char[] heap allocation in Encoder.ReadString()   if the input is less than 512 bytes. If it is less than this threshold, a stack allocated char[] is used. The only allocation within the method is then the actual result string. The number 512 is a bit arbitrary, but it should be big enough to cover most strings and still small enough to not cause problems on deep stacks or constrained devices.
The benchmark results in this case are less clear, with the stackalloc version being slower. But I think this optimization is still worth it due to the reduced allocations.

```
         Method | StringLength |        Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
--------------- |------------- |------------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 ReadString_Old |            1 |    68.28 ns |  1.457 ns |  3.734 ns |      0.0203 |           - |           - |                32 B |
 ReadString_New |            1 |    81.24 ns |  1.873 ns |  5.463 ns |      0.0101 |           - |           - |                16 B |
 ReadString_Old |          128 |   368.67 ns |  7.401 ns |  9.880 ns |      0.3428 |           - |           - |               540 B |
 ReadString_New |          128 |   447.23 ns |  8.847 ns |  8.689 ns |      0.1931 |           - |           - |               304 B |
 ReadString_Old |         1024 | 2,128.03 ns | 39.030 ns | 34.599 ns |      2.6207 |           - |           - |              4128 B |
 ReadString_New |         1024 | 2,191.68 ns | 47.546 ns | 63.473 ns |      2.6207 |           - |           - |              4128 B |
```