### PR TITLE
Amqp Value should be encoded properly when value was not initialized

### DIFF
--- a/src/Framing/AmqpValue.cs
+++ b/src/Framing/AmqpValue.cs
@@ -89,7 +89,7 @@ namespace Amqp.Framing
             }
             else
             {
-                this.WriteValue(buffer, this.value);
+                this.WriteValue(buffer, this.Value);
             }
         }
 

--- a/test/Common/ContainerHostTests.cs
+++ b/test/Common/ContainerHostTests.cs
@@ -1075,6 +1075,26 @@ namespace Test.Amqp
         }
 #endif
 
+        [TestMethod]
+        public void EncodeDecodeMessageWithAmqpValueTest()
+        {
+            string name = "EncodeDecodeMessageWithAmqpValueTest";
+            Queue<Message> messages = new Queue<Message>();
+            messages.Enqueue(new Message("test") { Properties = new Properties() { MessageId = name } });
+
+            var source = new TestMessageSource(messages);
+            this.host.RegisterMessageSource(name, source);
+
+            var connection = new Connection(Address);
+            var session = new Session(connection);
+            var receiver = new ReceiverLink(session, "receiver0", name);
+
+            Message message = receiver.Receive();
+            Message copy = Message.Decode(message.Encode());
+
+            Assert.AreEqual((message.BodySection as AmqpValue).Value, (copy.BodySection as AmqpValue).Value);
+        }
+
         public static X509Certificate2 GetCertificate(StoreLocation storeLocation, StoreName storeName, string certFindValue)
         {
             X509Store store = new X509Store(storeName, storeLocation);


### PR DESCRIPTION
In nms-amqp we are using Message Encode/Decode methods to create message deep copy before we actually pass the message to the application. It is necessary in order to support session recovery scenario. (User shouldn't be able to mutate underlying message as it may be redelivered in the future).

https://github.com/apache/activemq-nms-amqp/blob/1a2d9b5cd27c25731b02568d7cf00cf92011e9cf/src/NMS.AMQP/Provider/Amqp/Message/AmqpNmsMessageFacade.cs#L430-L443

I found that there is a problem if you try to Encode/Decode message with AmqpValue payload, as it's not encoded properly if message value wasn't initialized before.

https://github.com/Azure/amqpnetlite/blob/abf0504cc9c6306e5da429d0e9eaec34873d97ae/src/Framing/AmqpValue.cs#L44-L54

If you do not explicitly call Value getter or setter, underlying value field will never be set. As it is later used to in EncodeValue we have a bug.

https://github.com/Azure/amqpnetlite/blob/abf0504cc9c6306e5da429d0e9eaec34873d97ae/src/Framing/AmqpValue.cs#L92

I've attached unit test illustrating the problem alongside with suggested solution. The problem only occur, when message arrive from the broker, if you try to encode message created in application it works fine, as value is already initialized. 

I'm not sure if I put test in the right place, but to illustrate the problem I need a broker to send a message "over the wire". 