### PR TITLE
All Frames should have public access modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ DOTNETMF_FS_EMULATION*/
 
 # dnx
 *project.lock.json
+.idea/

--- a/src/Framing/Close.cs
+++ b/src/Framing/Close.cs
@@ -19,19 +19,31 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class Close : DescribedList
+    /// <summary>
+    /// The Close class contains parameters to signal a connection close. 
+    /// </summary>
+    public sealed class Close : DescribedList
     {
+        /// <summary>
+        /// Initializes a Close object.
+        /// </summary>
         public Close()
             : base(Codec.Close, 1)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the error field.
+        /// </summary>
         public Error Error
         {
             get { return (Error)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current begin object.
+        /// </summary>
         public override string ToString()
         {
 #if TRACE

--- a/src/Framing/Detach.cs
+++ b/src/Framing/Detach.cs
@@ -19,31 +19,49 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class Detach : DescribedList
+    /// <summary>
+    /// The Detach class contains parameters to detach the link endpoint from the session.
+    /// </summary>
+    public sealed class Detach : DescribedList
     {
+        /// <summary>
+        /// Initializes a Detach object.
+        /// </summary>
         public Detach()
             : base(Codec.Detach, 3)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the handle field.
+        /// </summary>
         public uint Handle
         {
             get { return this.Fields[0] == null ? uint.MinValue : (uint)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the closed field.
+        /// </summary>
         public bool Closed
         {
             get { return this.Fields[1] == null ? false : (bool)this.Fields[1]; }
             set { this.Fields[1] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the error field.
+        /// </summary>
         public Error Error
         {
             get { return (Error)this.Fields[2]; }
             set { this.Fields[2] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current begin object.
+        /// </summary>
         public override string ToString()
         {
 #if TRACE

--- a/src/Framing/Dispose.cs
+++ b/src/Framing/Dispose.cs
@@ -19,49 +19,76 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class Dispose : DescribedList
+    /// <summary>
+    /// The Dispose class defines a disposition frame to inform remote peer of delivery state changes.
+    /// </summary>
+    public sealed class Dispose : DescribedList
     {
+        /// <summary>
+        /// Initializes a dispose object.
+        /// </summary>
         public Dispose()
             : base(Codec.Dispose, 6)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the role field.
+        /// </summary>
         public bool Role
         {
             get { return this.Fields[0] == null ? false : (bool)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the first field.
+        /// </summary>
         public uint First
         {
             get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
             set { this.Fields[1] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the last field.
+        /// </summary>
         public uint Last
         {
             get { return this.Fields[2] == null ? this.First : (uint)this.Fields[2]; }
             set { this.Fields[2] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the settled field. 
+        /// </summary>
         public bool Settled
         {
             get { return this.Fields[3] == null ? false : (bool)this.Fields[3]; }
             set { this.Fields[3] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the state field.
+        /// </summary>
         public DeliveryState State
         {
             get { return (DeliveryState)this.Fields[4]; }
             set { this.Fields[4] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the batchable field 
+        /// </summary>
         public bool Batchable
         {
             get { return this.Fields[5] == null ? false : (bool)this.Fields[5]; }
             set { this.Fields[5] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
         public override string ToString()
         {
 #if TRACE

--- a/src/Framing/End.cs
+++ b/src/Framing/End.cs
@@ -19,19 +19,31 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class End : DescribedList
+    /// <summary>
+    /// The End class defines an end frame that indicates that the session has ended.
+    /// </summary>
+    public sealed class End : DescribedList
     {
+        /// <summary>
+        /// Initializes an end object.
+        /// </summary>
         public End()
             : base(Codec.End, 1)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the error field.
+        /// </summary>
         public Error Error
         {
             get { return (Error)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current begin object. 
+        /// </summary>
         public override string ToString()
         {
 #if TRACE

--- a/src/Framing/Flow.cs
+++ b/src/Framing/Flow.cs
@@ -19,84 +19,129 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class Flow : DescribedList
+    /// <summary>
+    /// The Flow class defines a flow frame that updates the flow state for the specified link.
+    /// </summary>
+    public sealed class Flow : DescribedList
     {
+        /// <summary>
+        /// Initializes a flow object.
+        /// </summary>
         public Flow()
             : base(Codec.Flow, 11)
         {
         }
 
+        /// <summary>
+        /// Indicates if handle field was defined.
+        /// </summary>
         public bool HasHandle
         {
             get { return this.Fields[4] != null; }
         }
 
+        /// <summary>
+        /// Gets or sets the next-incoming-id field. 
+        /// </summary>
         public uint NextIncomingId
         {
             get { return this.Fields[0] == null ? uint.MinValue : (uint)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the incoming-window field. 
+        /// </summary>
         public uint IncomingWindow
         {
             get { return this.Fields[1] == null ? uint.MaxValue : (uint)this.Fields[1]; }
             set { this.Fields[1] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the next-outgoing-id field. 
+        /// </summary>
         public uint NextOutgoingId
         {
             get { return this.Fields[2] == null ? uint.MinValue : (uint)this.Fields[2]; }
             set { this.Fields[2] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the outgoing-window field.
+        /// </summary>
         public uint OutgoingWindow
         {
             get { return this.Fields[3] == null ? uint.MaxValue : (uint)this.Fields[3]; }
             set { this.Fields[3] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the handle field.
+        /// </summary>
         public uint Handle
         {
             get { return this.Fields[4] == null ? uint.MaxValue : (uint)this.Fields[4]; }
             set { this.Fields[4] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the delivery-count field.
+        /// </summary>
         public uint DeliveryCount
         {
             get { return this.Fields[5] == null ? uint.MinValue : (uint)this.Fields[5]; }
             set { this.Fields[5] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the link-credit field. 
+        /// </summary>
         public uint LinkCredit
         {
             get { return this.Fields[6] == null ? uint.MinValue : (uint)this.Fields[6]; }
             set { this.Fields[6] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the available field.
+        /// </summary>
         public uint Available
         {
             get { return this.Fields[7] == null ? uint.MinValue : (uint)this.Fields[7]; }
             set { this.Fields[7] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the drain field.
+        /// </summary>
         public bool Drain
         {
             get { return this.Fields[8] == null ? false : (bool)this.Fields[8]; }
             set { this.Fields[8] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the echo field.
+        /// </summary>
         public bool Echo
         {
             get { return this.Fields[9] == null ? false : (bool)this.Fields[9]; }
             set { this.Fields[9] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the properties field.
+        /// </summary>
         public Fields Properties
         {
             get { return Amqp.Types.Fields.From(this.Fields, 10); }
             set { this.Fields[10] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
         public override string ToString()
         {
 #if TRACE

--- a/src/Framing/Transfer.cs
+++ b/src/Framing/Transfer.cs
@@ -19,84 +19,130 @@ namespace Amqp.Framing
 {
     using Amqp.Types;
 
-    sealed class Transfer : DescribedList
+    /// <summary>
+    /// The Transfer class defines an transfer frame to send messages across a link. 
+    /// </summary>
+    public sealed class Transfer : DescribedList
     {
+        /// <summary>
+        /// Initializes an transfer object.
+        /// </summary>
         public Transfer()
             : base(Codec.Transfer, 11)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the delivery-id field.
+        /// </summary>
         public bool HasDeliveryId
         {
             get { return this.Fields[1] != null; }
         }
 
+        /// <summary>
+        /// Gets or sets the handle field.
+        /// </summary>
         public uint Handle
         {
             get { return this.Fields[0] == null ? uint.MaxValue : (uint)this.Fields[0]; }
             set { this.Fields[0] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the delivery-id field. 
+        /// </summary>
         public uint DeliveryId
         {
             get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
             set { this.Fields[1] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the delivery-tag field.
+        /// </summary>
         public byte[] DeliveryTag
         {
             get { return (byte[])this.Fields[2]; }
             set { this.Fields[2] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the message-format field.
+        /// </summary>
         public uint MessageFormat
         {
             get { return this.Fields[3] == null ? uint.MinValue : (uint)this.Fields[3]; }
             set { this.Fields[3] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the settled field.
+        /// </summary>
         public bool Settled
         {
             get { return this.Fields[4] == null ? false : (bool)this.Fields[4]; }
             set { this.Fields[4] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the more field.
+        /// </summary>
         public bool More
         {
             get { return this.Fields[5] == null ? false : (bool)this.Fields[5]; }
             set { this.Fields[5] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the rcv-settle-mode field.
+        /// </summary>
         public ReceiverSettleMode RcvSettleMode
         {
             get { return this.Fields[6] == null ? ReceiverSettleMode.First : (ReceiverSettleMode)this.Fields[6]; }
             set { this.Fields[6] = (byte)value; }
         }
 
+        /// <summary>
+        /// Gets or sets the state field.
+        /// </summary>
         public DeliveryState State
         {
             get { return (DeliveryState)this.Fields[7]; }
             set { this.Fields[7] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the resume field.
+        /// </summary>
         public bool Resume
         {
             get { return this.Fields[8] == null ? false : (bool)this.Fields[8]; }
             set { this.Fields[8] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the aborted field.
+        /// </summary>
         public bool Aborted
         {
             get { return this.Fields[9] == null ? false : (bool)this.Fields[9]; }
             set { this.Fields[9] = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the batchable field.
+        /// </summary>
         public bool Batchable
         {
             get { return this.Fields[10] == null ? false : (bool)this.Fields[10]; }
             set { this.Fields[10] = value; }
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
 #if TRACE


### PR DESCRIPTION
I am working on integration testing toolkit for NMS AMQP https://github.com/apache/activemq-nms-amqp/pull/9. The functionality is based on [Qpid JMS frame by frame assertions](https://github.com/apache/qpid-jms/blob/ebf2b444833fc184f81de71f806f6a54fdabe519/qpid-jms-client/src/test/java/org/apache/qpid/jms/test/testpeer/TestAmqpPeer.java). As we are using amqpnetlite under the hood I would like to make assertions using amqpnetlite types, and do not rewrite the logic responsible for encoding and decoding frames. 

In the process I realized that not all required frames have public access modifiers. This PR addresses this issue. 