### PR TITLE
Optimize allocations in types derived from DescribedList

### DIFF
--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -261,7 +261,10 @@ namespace Amqp
                     this.heartBeat.OnSend();
                 }
 
-                Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1}", channel, command);
+                if (Trace.TraceLevel >= TraceLevel.Frame)
+                {
+                    Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1}", channel, command);
+                }
             }
         }
 
@@ -300,7 +303,10 @@ namespace Amqp
 
             payload.Complete(payloadSize);
             this.writer.Send(frameBuffer);
-            Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1} payload {2}", channel, transfer, payloadSize);
+            if (Trace.TraceLevel >= TraceLevel.Frame)
+            {
+                Trace.WriteLine(TraceLevel.Frame, "SEND (ch={0}) {1} payload {2}", channel, transfer, payloadSize);
+            }
 
             return payloadSize;
         }
@@ -604,13 +610,16 @@ namespace Amqp
                 ushort channel;
                 DescribedList command;
                 Frame.Decode(buffer, out channel, out command);
-                if (buffer.Length > 0)
+                if (Trace.TraceLevel >= TraceLevel.Frame)
                 {
-                    Trace.WriteLine(TraceLevel.Frame, "RECV (ch={0}) {1} payload {2}", channel, command, buffer.Length);
-                }
-                else
-                {
-                    Trace.WriteLine(TraceLevel.Frame, "RECV (ch={0}) {1}", channel, command);
+                    if (buffer.Length > 0)
+                    {
+                        Trace.WriteLine(TraceLevel.Frame, "RECV (ch={0}) {1} payload {2}", channel, command, buffer.Length);
+                    }
+                    else
+                    {
+                        Trace.WriteLine(TraceLevel.Frame, "RECV (ch={0}) {1}", channel, command);
+                    }
                 }
 
                 if (this.heartBeat != null)

--- a/src/Framing/Accepted.cs
+++ b/src/Framing/Accepted.cs
@@ -42,7 +42,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "accepted",
                 new object[0],
-                this.Fields);
+                new object[0]);
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Accepted.cs
+++ b/src/Framing/Accepted.cs
@@ -32,6 +32,16 @@ namespace Amqp.Framing
         {
         }
 
+        internal override void WriteField(ByteBuffer buffer, int index)
+        {
+            Fx.Assert(false, "Invalid field index");
+        }
+
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
+        {
+            Fx.Assert(false, "Invalid field index");
+        }
+
         /// <summary>
         /// Returns a string that represents the current accepted outcome.
         /// </summary>

--- a/src/Framing/Attach.cs
+++ b/src/Framing/Attach.cs
@@ -24,6 +24,21 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Attach : DescribedList
     {
+        string linkName;
+        uint handle;
+        bool role;
+        SenderSettleMode sndSettleMode;
+        ReceiverSettleMode rcvSettleMode;
+        object source;
+        object target;
+        Map unsettled;
+        bool incompleteUnsettled;
+        uint initialDeliveryCount;
+        ulong maxMessageSize;
+        object offeredCapabilities;
+        object desiredCapabilities;
+        Fields properties;
+
         /// <summary>
         /// Initializes an attach object.
         /// </summary>
@@ -32,235 +47,234 @@ namespace Amqp.Framing
         {
         }
 
-        private string linkName;
         /// <summary>
         /// Gets or sets the name field.
         /// </summary>
         public string LinkName
         {
-            get { return this.linkName; }
-            set { this.linkName = value; }
+            get { return this.GetField(0, this.linkName); }
+            set { this.SetField(0, ref this.linkName, value); }
         }
 
-        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.handle == null ? uint.MinValue : this.handle.Value; }
-            set { this.handle = value; }
+            get { return this.GetField(1, this.handle, uint.MinValue); }
+            set { this.SetField(1, ref this.handle, value); }
         }
 
-        private bool? role;
         /// <summary>
         /// Gets or sets the role field.
         /// </summary>
         public bool Role
         {
-            get { return this.role == null ? false : this.role.Value; }
-            set { this.role = value; }
+            get { return this.GetField(2, this.role, false); }
+            set { this.SetField(2, ref this.role, value); }
         }
 
-        private SenderSettleMode? sndSettleMode;
         /// <summary>
         /// Gets or sets the snd-settle-mode field.
         /// </summary>
         public SenderSettleMode SndSettleMode
         {
-            get { return this.sndSettleMode == null ? SenderSettleMode.Unsettled : this.sndSettleMode.Value; }
-            set { this.sndSettleMode = value; }
+            get { return this.GetField(3, this.sndSettleMode, SenderSettleMode.Unsettled); }
+            set { this.SetField(3, ref this.sndSettleMode, value); }
         }
 
-        private ReceiverSettleMode? rcvSettleMode;
         /// <summary>
         /// Gets or sets the rcv-settle-mode field.
         /// </summary>
         public ReceiverSettleMode RcvSettleMode
         {
-            get { return this.rcvSettleMode == null ? ReceiverSettleMode.First : this.rcvSettleMode.Value; }
-            set { this.rcvSettleMode = value; }
+            get { return this.GetField(4, this.rcvSettleMode, ReceiverSettleMode.First); }
+            set { this.SetField(4, ref this.rcvSettleMode, value); }
         }
 
-        private object source;
         /// <summary>
         /// Gets or sets the source field.
         /// </summary>
         public object Source
         {
-            get { return this.source; }
-            set { this.source = value; }
+            get { return this.GetField(5, this.source); }
+            set { this.SetField(5, ref this.source, value); }
         }
 
-        private object target;
         /// <summary>
         /// Gets or sets the target field.
         /// </summary>
         public object Target
         {
-            get { return this.target; }
-            set { this.target = value; }
+            get { return this.GetField(6, this.target); }
+            set { this.SetField(6, ref this.target, value); }
         }
 
-        private Map unsettled;
         /// <summary>
         /// Gets or sets the unsettled field.
         /// </summary>
         public Map Unsettled
         {
-            get { return this.unsettled; }
-            set { this.unsettled = value; }
+            get { return this.GetField(7, this.unsettled); }
+            set { this.SetField(7, ref this.unsettled, value); }
         }
 
-        private bool? incompleteUnsettled;
         /// <summary>
         /// Gets or sets the incomplete-unsettled field.
         /// </summary>
         public bool IncompleteUnsettled
         {
-            get { return this.incompleteUnsettled == null ? false : this.incompleteUnsettled.Value; }
-            set { this.incompleteUnsettled = value; }
+            get { return this.GetField(8, this.incompleteUnsettled, false); }
+            set { this.SetField(8, ref this.incompleteUnsettled, value); }
         }
 
-        private uint? initialDeliveryCount;
         /// <summary>
         /// Gets or sets the initial-delivery-count field.
         /// </summary>
         public uint InitialDeliveryCount
         {
-            get { return this.initialDeliveryCount == null ? uint.MinValue : this.initialDeliveryCount.Value; }
-            set { this.initialDeliveryCount = value; }
+            get { return this.GetField(9, this.initialDeliveryCount, uint.MinValue); }
+            set { this.SetField(9, ref this.initialDeliveryCount, value); }
         }
 
-        private ulong? maxMessageSize;
         /// <summary>
         /// Gets or sets the max-message-size field.
         /// </summary>
         public ulong MaxMessageSize
         {
-            get { return this.maxMessageSize == null ? ulong.MaxValue : (ulong)this.maxMessageSize; }
-            set { this.maxMessageSize = value; }
+            get { return this.GetField(10, this.maxMessageSize, ulong.MaxValue); }
+            set { this.SetField(10, ref this.maxMessageSize, value); }
         }
 
-        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
-            set { this.offeredCapabilities = value; }
+            get { return HasField(11) ? Codec.GetSymbolMultiple(ref this.offeredCapabilities) : null; }
+            set { this.SetField(11, ref this.offeredCapabilities, value); }
         }
 
-        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
-            set { this.desiredCapabilities = value; }
+            get { return HasField(12) ? Codec.GetSymbolMultiple(ref this.desiredCapabilities) : null; }
+            set { this.SetField(12, ref this.desiredCapabilities, value); }
         }
 
-        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return properties; }
-            set { this.properties = value; }
+            get { return this.GetField(13, this.properties); }
+            set { this.SetField(13, ref this.properties, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.linkName = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.handle = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.role = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.sndSettleMode = (SenderSettleMode)Encoder.ReadUByte(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.source = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.target = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.unsettled = Encoder.ReadMap(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.incompleteUnsettled = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.initialDeliveryCount = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.maxMessageSize = Encoder.ReadULong(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.offeredCapabilities = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.desiredCapabilities = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.properties = Encoder.ReadFields(buffer);
+                case 0:
+                    Encoder.WriteString(buffer, this.linkName, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.handle, true);
+                    break;
+                case 2:
+                    Encoder.WriteBoolean(buffer, this.role, true);
+                    break;
+                case 3:
+                    Encoder.WriteUByte(buffer, (byte)this.sndSettleMode);
+                    break;
+                case 4:
+                    Encoder.WriteUByte(buffer, (byte)this.rcvSettleMode);
+                    break;
+                case 5:
+                    Encoder.WriteObject(buffer, this.source);
+                    break;
+                case 6:
+                    Encoder.WriteObject(buffer, this.target);
+                    break;
+                case 7:
+                    Encoder.WriteMap(buffer, this.unsettled, true);
+                    break;
+                case 8:
+                    Encoder.WriteBoolean(buffer, this.incompleteUnsettled, true);
+                    break;
+                case 9:
+                    Encoder.WriteUInt(buffer, this.initialDeliveryCount, true);
+                    break;
+                case 10:
+                    Encoder.WriteULong(buffer, this.maxMessageSize, true);
+                    break;
+                case 11:
+                    Encoder.WriteObject(buffer, this.offeredCapabilities);
+                    break;
+                case 12:
+                    Encoder.WriteObject(buffer, this.desiredCapabilities);
+                    break;
+                case 13:
+                    Encoder.WriteMap(buffer, this.properties, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteString(buffer, linkName, true);
-            Encoder.WriteUInt(buffer, handle, true);
-            Encoder.WriteBoolean(buffer, role, true);
-            Encoder.WriteUByte(buffer, (byte?)sndSettleMode);
-            Encoder.WriteUByte(buffer, (byte?)rcvSettleMode);
-            Encoder.WriteObject(buffer, source, true);
-            Encoder.WriteObject(buffer, target, true);
-            Encoder.WriteMap(buffer, unsettled, true);
-            Encoder.WriteBoolean(buffer, incompleteUnsettled, true);
-            Encoder.WriteUInt(buffer, initialDeliveryCount, true);
-            Encoder.WriteULong(buffer, maxMessageSize, true);
-            Encoder.WriteObject(buffer, offeredCapabilities, true);
-            Encoder.WriteObject(buffer, desiredCapabilities, true);
-            Encoder.WriteMap(buffer, properties, true);
+            switch (index)
+            {
+                case 0:
+                    this.linkName = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 1:
+                    this.handle = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.role = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 3:
+                    this.sndSettleMode = (SenderSettleMode)Encoder.ReadUByte(buffer, formatCode);
+                    break;
+                case 4:
+                    this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer, formatCode);
+                    break;
+                case 5:
+                    this.source = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 6:
+                    this.target = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 7:
+                    this.unsettled = Encoder.ReadMap(buffer, formatCode);
+                    break;
+                case 8:
+                    this.incompleteUnsettled = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 9:
+                    this.initialDeliveryCount = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 10:
+                    this.maxMessageSize = Encoder.ReadULong(buffer, formatCode);
+                    break;
+                case 11:
+                    this.offeredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 12:
+                    this.desiredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 13:
+                    this.properties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Framing/Attach.cs
+++ b/src/Framing/Attach.cs
@@ -32,132 +32,237 @@ namespace Amqp.Framing
         {
         }
 
+        private string linkName;
         /// <summary>
         /// Gets or sets the name field.
         /// </summary>
         public string LinkName
         {
-            get { return (string)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.linkName; }
+            set { this.linkName = value; }
         }
 
+        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.handle == null ? uint.MinValue : this.handle.Value; }
+            set { this.handle = value; }
         }
 
+        private bool? role;
         /// <summary>
         /// Gets or sets the role field.
         /// </summary>
         public bool Role
         {
-            get { return this.Fields[2] == null ? false : (bool)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.role == null ? false : this.role.Value; }
+            set { this.role = value; }
         }
 
+        private SenderSettleMode? sndSettleMode;
         /// <summary>
         /// Gets or sets the snd-settle-mode field.
         /// </summary>
         public SenderSettleMode SndSettleMode
         {
-            get { return this.Fields[3] == null ? SenderSettleMode.Unsettled : (SenderSettleMode)this.Fields[3]; }
-            set { this.Fields[3] = (byte)value; }
+            get { return this.sndSettleMode == null ? SenderSettleMode.Unsettled : this.sndSettleMode.Value; }
+            set { this.sndSettleMode = value; }
         }
 
+        private ReceiverSettleMode? rcvSettleMode;
         /// <summary>
         /// Gets or sets the rcv-settle-mode field.
         /// </summary>
         public ReceiverSettleMode RcvSettleMode
         {
-            get { return this.Fields[4] == null ? ReceiverSettleMode.First : (ReceiverSettleMode)this.Fields[4]; }
-            set { this.Fields[4] = (byte)value; }
+            get { return this.rcvSettleMode == null ? ReceiverSettleMode.First : this.rcvSettleMode.Value; }
+            set { this.rcvSettleMode = value; }
         }
 
+        private object source;
         /// <summary>
         /// Gets or sets the source field.
         /// </summary>
         public object Source
         {
-            get { return this.Fields[5]; }
-            set { this.Fields[5] = value; }
+            get { return this.source; }
+            set { this.source = value; }
         }
 
+        private object target;
         /// <summary>
         /// Gets or sets the target field.
         /// </summary>
         public object Target
         {
-            get { return this.Fields[6]; }
-            set { this.Fields[6] = value; }
+            get { return this.target; }
+            set { this.target = value; }
         }
 
+        private Map unsettled;
         /// <summary>
         /// Gets or sets the unsettled field.
         /// </summary>
         public Map Unsettled
         {
-            get { return (Map)this.Fields[7]; }
-            set { this.Fields[7] = value; }
+            get { return this.unsettled; }
+            set { this.unsettled = value; }
         }
 
+        private bool? incompleteUnsettled;
         /// <summary>
         /// Gets or sets the incomplete-unsettled field.
         /// </summary>
         public bool IncompleteUnsettled
         {
-            get { return this.Fields[8] == null ? false : (bool)this.Fields[8]; }
-            set { this.Fields[8] = value; }
+            get { return this.incompleteUnsettled == null ? false : this.incompleteUnsettled.Value; }
+            set { this.incompleteUnsettled = value; }
         }
 
+        private uint? initialDeliveryCount;
         /// <summary>
         /// Gets or sets the initial-delivery-count field.
         /// </summary>
         public uint InitialDeliveryCount
         {
-            get { return this.Fields[9] == null ? uint.MinValue : (uint)this.Fields[9]; }
-            set { this.Fields[9] = value; }
+            get { return this.initialDeliveryCount == null ? uint.MinValue : this.initialDeliveryCount.Value; }
+            set { this.initialDeliveryCount = value; }
         }
 
+        private ulong? maxMessageSize;
         /// <summary>
         /// Gets or sets the max-message-size field.
         /// </summary>
         public ulong MaxMessageSize
         {
-            get { return this.Fields[10] == null ? ulong.MaxValue : (ulong)this.Fields[10]; }
-            set { this.Fields[10] = value; }
+            get { return this.maxMessageSize == null ? ulong.MaxValue : (ulong)this.maxMessageSize; }
+            set { this.maxMessageSize = value; }
         }
 
+        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 11); }
-            set { this.Fields[11] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
+            set { this.offeredCapabilities = value; }
         }
 
+        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 12); }
-            set { this.Fields[12] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
+            set { this.desiredCapabilities = value; }
         }
 
+        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 13); }
-            set { this.Fields[13] = value; }
+            get { return properties; }
+            set { this.properties = value; }
         }
-        
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.linkName = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.handle = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.role = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.sndSettleMode = (SenderSettleMode)Encoder.ReadUByte(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.source = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.target = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.unsettled = Encoder.ReadMap(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.incompleteUnsettled = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.initialDeliveryCount = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.maxMessageSize = Encoder.ReadULong(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.offeredCapabilities = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.desiredCapabilities = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.properties = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteString(buffer, linkName, true);
+            Encoder.WriteUInt(buffer, handle, true);
+            Encoder.WriteBoolean(buffer, role, true);
+            Encoder.WriteUByte(buffer, (byte?)sndSettleMode);
+            Encoder.WriteUByte(buffer, (byte?)rcvSettleMode);
+            Encoder.WriteObject(buffer, source, true);
+            Encoder.WriteObject(buffer, target, true);
+            Encoder.WriteMap(buffer, unsettled, true);
+            Encoder.WriteBoolean(buffer, incompleteUnsettled, true);
+            Encoder.WriteUInt(buffer, initialDeliveryCount, true);
+            Encoder.WriteULong(buffer, maxMessageSize, true);
+            Encoder.WriteObject(buffer, offeredCapabilities, true);
+            Encoder.WriteObject(buffer, desiredCapabilities, true);
+            Encoder.WriteMap(buffer, properties, true);
+        }
+
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current object.
@@ -168,7 +273,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "attach",
                 new object[] { "name", "handle", "role", "snd-settle-mode", "rcv-settle-mode", "source", "target", "unsettled", "incomplete-unsettled", "initial-delivery-count", "max-message-size", "offered-capabilities", "desired-capabilities", "properties" },
-                this.Fields);
+                new object[] { linkName, handle, role, sndSettleMode, rcvSettleMode, source, target, unsettled, incompleteUnsettled, initialDeliveryCount, maxMessageSize, offeredCapabilities, desiredCapabilities, properties });
         }
 #endif
     }

--- a/src/Framing/Begin.cs
+++ b/src/Framing/Begin.cs
@@ -24,6 +24,15 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Begin : DescribedList
     {
+        ushort remoteChannel;
+        uint nextOutgoingId;
+        uint incomingWindow;
+        uint outgoingWindow;
+        uint handleMax;
+        object offeredCapabilities;
+        object desiredCapabilities;
+        Fields properties;
+
         /// <summary>
         /// Initializes a Begin object.
         /// </summary>
@@ -32,141 +41,146 @@ namespace Amqp.Framing
         {
         }
 
-        private ushort? remoteChannel;
         /// <summary>
         /// Gets or sets the remote-channel field.
         /// </summary>
         public ushort RemoteChannel
         {
-            get { return this.remoteChannel == null ? ushort.MaxValue : this.remoteChannel.Value; }
-            set { this.remoteChannel = value; }
+            get { return this.GetField(0, this.remoteChannel, ushort.MaxValue); }
+            set { this.SetField(0, ref this.remoteChannel, value); }
         }
 
-        private uint? nextOutgoingId;
         /// <summary>
         /// Gets or sets the next-outgoing-id field.
         /// </summary>
         public uint NextOutgoingId
         {
-            get { return this.nextOutgoingId == null ? uint.MinValue : this.nextOutgoingId.Value; }
-            set { this.nextOutgoingId = value; }
+            get { return this.GetField(1, this.nextOutgoingId, uint.MinValue); }
+            set { this.SetField(1, ref this.nextOutgoingId, value); }
         }
 
-        private uint? incomingWindow;
         /// <summary>
         /// Gets or sets the incoming-window field.
         /// </summary>
         public uint IncomingWindow
         {
-            get { return this.incomingWindow == null ? uint.MaxValue : this.incomingWindow.Value; }
-            set { this.incomingWindow = value; }
+            get { return this.GetField(2, this.incomingWindow, uint.MaxValue); }
+            set { this.SetField(2, ref this.incomingWindow, value); }
         }
 
-        private uint? outgoingWindow;
         /// <summary>
         /// Gets or sets the outgoing-window field.
         /// </summary>
         public uint OutgoingWindow
         {
-            get { return this.outgoingWindow == null ? uint.MaxValue : this.outgoingWindow.Value; }
-            set { this.outgoingWindow = value; }
+            get { return this.GetField(3, this.outgoingWindow, uint.MaxValue); }
+            set { this.SetField(3, ref this.outgoingWindow, value); }
         }
 
-        private uint? handleMax;
         /// <summary>
         /// Gets or sets the handle-max field.
         /// </summary>
         public uint HandleMax
         {
-            get { return this.handleMax == null ? uint.MaxValue : this.handleMax.Value; }
-            set { this.handleMax = value; }
+            get { return this.GetField(4, this.handleMax, uint.MaxValue); }
+            set { this.SetField(4, ref this.handleMax, value); }
         }
 
-        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
-            set { this.offeredCapabilities = value; }
+            get { return HasField(5) ? Codec.GetSymbolMultiple(ref this.offeredCapabilities) : null; }
+            set { this.SetField(5, ref this.offeredCapabilities, value); }
         }
 
-        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
-            set { this.desiredCapabilities = value; }
+            get { return HasField(6) ? Codec.GetSymbolMultiple(ref this.desiredCapabilities) : null; }
+            set { this.SetField(6, ref this.desiredCapabilities, value); }
         }
 
-        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return this.properties; }
-            set { this.properties = value; }
+            get { return this.GetField(7, this.properties); }
+            set { this.SetField(7, ref this.properties, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.remoteChannel = Encoder.ReadUShort(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.nextOutgoingId = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.incomingWindow = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.outgoingWindow = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.handleMax = Encoder.ReadUInt(buffer);
-            }
-            
-            if (count-- > 0)
-            {
-                this.offeredCapabilities = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.desiredCapabilities = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.properties = Encoder.ReadFields(buffer);
+                case 0:
+                    Encoder.WriteUShort(buffer, this.remoteChannel);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.nextOutgoingId, true);
+                    break;
+                case 2:
+                    Encoder.WriteUInt(buffer, this.incomingWindow, true);
+                    break;
+                case 3:
+                    Encoder.WriteUInt(buffer, this.outgoingWindow, true);
+                    break;
+                case 4:
+                    Encoder.WriteUInt(buffer, this.handleMax, true);
+                    break;
+                case 5:
+                    Encoder.WriteObject(buffer, this.offeredCapabilities);
+                    break;
+                case 6:
+                    Encoder.WriteObject(buffer, this.desiredCapabilities);
+                    break;
+                case 7:
+                    Encoder.WriteMap(buffer, this.properties, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteUShort(buffer, remoteChannel);
-            Encoder.WriteUInt(buffer, nextOutgoingId, true);
-            Encoder.WriteUInt(buffer, incomingWindow, true);
-            Encoder.WriteUInt(buffer, outgoingWindow, true);
-            Encoder.WriteUInt(buffer, handleMax, true);
-            Encoder.WriteObject(buffer, offeredCapabilities, true);
-            Encoder.WriteObject(buffer, desiredCapabilities, true);
-            Encoder.WriteMap(buffer, properties, true);
+            switch (index)
+            {
+                case 0:
+                    this.remoteChannel = Encoder.ReadUShort(buffer, formatCode);
+                    break;
+                case 1:
+                    this.nextOutgoingId = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.incomingWindow = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 3:
+                    this.outgoingWindow = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 4:
+                    this.handleMax = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 5:
+                    this.offeredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 6:
+                    this.desiredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 7:
+                    this.properties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
         /// <summary>
         /// Returns a string that represents the current begin object.
         /// </summary>

--- a/src/Framing/Begin.cs
+++ b/src/Framing/Begin.cs
@@ -32,76 +32,139 @@ namespace Amqp.Framing
         {
         }
 
+        private ushort? remoteChannel;
         /// <summary>
         /// Gets or sets the remote-channel field.
         /// </summary>
         public ushort RemoteChannel
         {
-            get { return this.Fields[0] == null ? ushort.MaxValue : (ushort)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.remoteChannel == null ? ushort.MaxValue : this.remoteChannel.Value; }
+            set { this.remoteChannel = value; }
         }
 
+        private uint? nextOutgoingId;
         /// <summary>
         /// Gets or sets the next-outgoing-id field.
         /// </summary>
         public uint NextOutgoingId
         {
-            get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.nextOutgoingId == null ? uint.MinValue : this.nextOutgoingId.Value; }
+            set { this.nextOutgoingId = value; }
         }
 
+        private uint? incomingWindow;
         /// <summary>
         /// Gets or sets the incoming-window field.
         /// </summary>
         public uint IncomingWindow
         {
-            get { return this.Fields[2] == null ? uint.MaxValue : (uint)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.incomingWindow == null ? uint.MaxValue : this.incomingWindow.Value; }
+            set { this.incomingWindow = value; }
         }
 
+        private uint? outgoingWindow;
         /// <summary>
         /// Gets or sets the outgoing-window field.
         /// </summary>
         public uint OutgoingWindow
         {
-            get { return this.Fields[3] == null ? uint.MaxValue : (uint)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.outgoingWindow == null ? uint.MaxValue : this.outgoingWindow.Value; }
+            set { this.outgoingWindow = value; }
         }
 
+        private uint? handleMax;
         /// <summary>
         /// Gets or sets the handle-max field.
         /// </summary>
         public uint HandleMax
         {
-            get { return this.Fields[4] == null ? uint.MaxValue : (uint)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.handleMax == null ? uint.MaxValue : this.handleMax.Value; }
+            set { this.handleMax = value; }
         }
 
+        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 5); }
-            set { this.Fields[5] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
+            set { this.offeredCapabilities = value; }
         }
 
+        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 6); }
-            set { this.Fields[6] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
+            set { this.desiredCapabilities = value; }
         }
 
+        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 7); }
-            set { this.Fields[7] = value; }
+            get { return this.properties; }
+            set { this.properties = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.remoteChannel = Encoder.ReadUShort(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.nextOutgoingId = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.incomingWindow = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.outgoingWindow = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.handleMax = Encoder.ReadUInt(buffer);
+            }
+            
+            if (count-- > 0)
+            {
+                this.offeredCapabilities = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.desiredCapabilities = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.properties = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUShort(buffer, remoteChannel);
+            Encoder.WriteUInt(buffer, nextOutgoingId, true);
+            Encoder.WriteUInt(buffer, incomingWindow, true);
+            Encoder.WriteUInt(buffer, outgoingWindow, true);
+            Encoder.WriteUInt(buffer, handleMax, true);
+            Encoder.WriteObject(buffer, offeredCapabilities, true);
+            Encoder.WriteObject(buffer, desiredCapabilities, true);
+            Encoder.WriteMap(buffer, properties, true);
         }
 
         /// <summary>
@@ -113,7 +176,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "begin",
                 new object[] { "remote-channel", "next-outgoing-id", "incoming-window", "outgoing-window", "handle-max", "offered-capabilities", "desired-capabilities", "properties" },
-                this.Fields);
+                new object[] {remoteChannel, nextOutgoingId, incomingWindow, outgoingWindow, handleMax, offeredCapabilities, desiredCapabilities, properties});
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Close.cs
+++ b/src/Framing/Close.cs
@@ -32,13 +32,27 @@ namespace Amqp.Framing
         {
         }
 
+        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return (Error)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.error; }
+            set { this.error = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.error = (Error)Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, error, true);
         }
 
         /// <summary>
@@ -50,7 +64,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "close",
                 new object[] { "error" },
-                this.Fields);
+                new object[] { error});
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Close.cs
+++ b/src/Framing/Close.cs
@@ -24,6 +24,8 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Close : DescribedList
     {
+        Error error;
+
         /// <summary>
         /// Initializes a Close object.
         /// </summary>
@@ -32,29 +34,41 @@ namespace Amqp.Framing
         {
         }
 
-        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return this.error; }
-            set { this.error = value; }
+            get { return this.GetField(0, this.error); }
+            set { this.SetField(0, ref this.error, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.error = (Error)Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.error);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, error, true);
+            switch (index)
+            {
+                case 0:
+                    this.error = (Error)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
         /// <summary>
         /// Returns a string that represents the current begin object.
         /// </summary>

--- a/src/Framing/Codec.cs
+++ b/src/Framing/Codec.cs
@@ -163,5 +163,29 @@ namespace Amqp.Framing
 
             throw new AmqpException(ErrorCode.InvalidField, Fx.Format("{0} {1}", index, fields[index].GetType().Name));
         }
+
+        public static Symbol[] GetSymbolMultiple(ref object obj)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            Symbol[] symbols = obj as Symbol[];
+            if (symbols != null)
+            {
+                return symbols;
+            }
+
+            Symbol symbol = obj as Symbol;
+            if (symbol != null)
+            {
+                symbols = new Symbol[] { symbol };
+                obj = symbols;
+                return symbols;
+            }
+
+            throw new AmqpException(ErrorCode.InvalidField, obj.GetType().Name);
+        }
     }
 }

--- a/src/Framing/Detach.cs
+++ b/src/Framing/Detach.cs
@@ -32,31 +32,59 @@ namespace Amqp.Framing
         {
         }
 
+        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.Fields[0] == null ? uint.MinValue : (uint)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.handle == null ? uint.MinValue : this.handle.Value; }
+            set { this.handle = value; }
         }
 
+        private bool? closed;
         /// <summary>
         /// Gets or sets the closed field.
         /// </summary>
         public bool Closed
         {
-            get { return this.Fields[1] == null ? false : (bool)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.closed == null ? false : this.closed.Value; }
+            set { this.closed = value; }
         }
 
+        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return (Error)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.error; }
+            set { this.error = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.handle = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.closed = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.error = (Error)Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUInt(buffer, handle, true);
+            Encoder.WriteBoolean(buffer, closed, true);
+            Encoder.WriteObject(buffer, error, true);
         }
 
         /// <summary>
@@ -68,7 +96,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "detach",
                 new object[] { "handle", "closed", "error" },
-                this.Fields);
+                new object[] { handle, closed, error });
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Detach.cs
+++ b/src/Framing/Detach.cs
@@ -24,6 +24,10 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Detach : DescribedList
     {
+        uint handle;
+        bool closed;
+        Error error;
+
         /// <summary>
         /// Initializes a Detach object.
         /// </summary>
@@ -32,59 +36,69 @@ namespace Amqp.Framing
         {
         }
 
-        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.handle == null ? uint.MinValue : this.handle.Value; }
-            set { this.handle = value; }
+            get { return this.GetField(0, this.handle, uint.MinValue); }
+            set { this.SetField(0, ref this.handle, value); }
         }
 
-        private bool? closed;
         /// <summary>
         /// Gets or sets the closed field.
         /// </summary>
         public bool Closed
         {
-            get { return this.closed == null ? false : this.closed.Value; }
-            set { this.closed = value; }
+            get { return this.GetField(1, this.closed, false); }
+            set { this.SetField(1, ref this.closed, value); }
         }
 
-        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return this.error; }
-            set { this.error = value; }
+            get { return this.GetField(2, this.error); }
+            set { this.SetField(2, ref this.error, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.handle = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.closed = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.error = (Error)Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteUInt(buffer, this.handle, true);
+                    break;
+                case 1:
+                    Encoder.WriteBoolean(buffer, this.closed, true);
+                    break;
+                case 2:
+                    Encoder.WriteObject(buffer, this.error, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteUInt(buffer, handle, true);
-            Encoder.WriteBoolean(buffer, closed, true);
-            Encoder.WriteObject(buffer, error, true);
+            switch (index)
+            {
+                case 0:
+                    this.handle = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 1:
+                    this.closed = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 2:
+                    this.error = (Error)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Framing/Dispose.cs
+++ b/src/Framing/Dispose.cs
@@ -24,6 +24,13 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Dispose : DescribedList
     {
+        bool role;
+        uint first;
+        uint last;
+        bool settled;
+        DeliveryState state;
+        bool batchable;
+
         /// <summary>
         /// Initializes a dispose object.
         /// </summary>
@@ -32,109 +39,116 @@ namespace Amqp.Framing
         {
         }
 
-        private bool? role;
         /// <summary>
         /// Gets or sets the role field.
         /// </summary>
         public bool Role
         {
-            get { return this.role == null ? false : this.role.Value; }
-            set { this.role = value; }
+            get { return this.GetField(0, this.role, false); }
+            set { this.SetField(0, ref this.role, value); }
         }
 
-        private uint? first;
         /// <summary>
         /// Gets or sets the first field.
         /// </summary>
         public uint First
         {
-            get { return this.first == null ? uint.MinValue : this.first.Value; }
-            set { this.first = value; }
+            get { return this.GetField(1, this.first, uint.MinValue); }
+            set { this.SetField(1, ref this.first, value); }
         }
 
-        private uint? last;
         /// <summary>
         /// Gets or sets the last field.
         /// </summary>
         public uint Last
         {
-            get { return this.last == null ? this.First : this.last.Value; }
-            set { this.last = value; }
+            get { return this.GetField(2, this.last, this.First); }
+            set { this.SetField(2, ref this.last, value); }
         }
 
-        private bool? settled;
         /// <summary>
         /// Gets or sets the settled field. 
         /// </summary>
         public bool Settled
         {
-            get { return this.settled == null ? false : this.settled.Value; }
-            set { this.settled = value; }
+            get { return this.GetField(3, this.settled, false); }
+            set { this.SetField(3, ref this.settled, value); }
         }
 
-        private DeliveryState state;
         /// <summary>
         /// Gets or sets the state field.
         /// </summary>
         public DeliveryState State
         {
-            get { return this.state; }
-            set { this.state = value; }
+            get { return this.GetField(4, this.state); }
+            set { this.SetField(4, ref this.state, value); }
         }
 
-        private bool? batchable;
         /// <summary>
         /// Gets or sets the batchable field 
         /// </summary>
         public bool Batchable
         {
-            get { return this.batchable == null ? false : this.batchable.Value; }
-            set { this.batchable = value; }
+            get { return this.GetField(5, this.batchable, false); }
+            set { this.SetField(5, ref this.batchable, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.role = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.first = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.last = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.settled = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.state = (DeliveryState)Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.batchable = Encoder.ReadBoolean(buffer);
+                case 0:
+                    Encoder.WriteBoolean(buffer, this.role, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.first, true);
+                    break;
+                case 2:
+                    Encoder.WriteUInt(buffer, this.last, true);
+                    break;
+                case 3:
+                    Encoder.WriteBoolean(buffer, this.settled, true);
+                    break;
+                case 4:
+                    Encoder.WriteObject(buffer, this.state);
+                    break;
+                case 5:
+                    Encoder.WriteBoolean(buffer, this.batchable, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBoolean(buffer, role, true);
-            Encoder.WriteUInt(buffer, first, true);
-            Encoder.WriteUInt(buffer, last, true);
-            Encoder.WriteBoolean(buffer, settled, true);
-            Encoder.WriteObject(buffer, state, true);
-            Encoder.WriteBoolean(buffer, batchable, true);
+            switch (index)
+            {
+                case 0:
+                    this.role = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 1:
+                    this.first = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.last = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 3:
+                    this.settled = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 4:
+                    this.state = (DeliveryState)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 5:
+                    this.batchable = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>

--- a/src/Framing/Dispose.cs
+++ b/src/Framing/Dispose.cs
@@ -32,58 +32,107 @@ namespace Amqp.Framing
         {
         }
 
+        private bool? role;
         /// <summary>
         /// Gets or sets the role field.
         /// </summary>
         public bool Role
         {
-            get { return this.Fields[0] == null ? false : (bool)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.role == null ? false : this.role.Value; }
+            set { this.role = value; }
         }
 
+        private uint? first;
         /// <summary>
         /// Gets or sets the first field.
         /// </summary>
         public uint First
         {
-            get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.first == null ? uint.MinValue : this.first.Value; }
+            set { this.first = value; }
         }
 
+        private uint? last;
         /// <summary>
         /// Gets or sets the last field.
         /// </summary>
         public uint Last
         {
-            get { return this.Fields[2] == null ? this.First : (uint)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.last == null ? this.First : this.last.Value; }
+            set { this.last = value; }
         }
 
+        private bool? settled;
         /// <summary>
         /// Gets or sets the settled field. 
         /// </summary>
         public bool Settled
         {
-            get { return this.Fields[3] == null ? false : (bool)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.settled == null ? false : this.settled.Value; }
+            set { this.settled = value; }
         }
 
+        private DeliveryState state;
         /// <summary>
         /// Gets or sets the state field.
         /// </summary>
         public DeliveryState State
         {
-            get { return (DeliveryState)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.state; }
+            set { this.state = value; }
         }
 
+        private bool? batchable;
         /// <summary>
         /// Gets or sets the batchable field 
         /// </summary>
         public bool Batchable
         {
-            get { return this.Fields[5] == null ? false : (bool)this.Fields[5]; }
-            set { this.Fields[5] = value; }
+            get { return this.batchable == null ? false : this.batchable.Value; }
+            set { this.batchable = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.role = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.first = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.last = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.settled = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.state = (DeliveryState)Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.batchable = Encoder.ReadBoolean(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBoolean(buffer, role, true);
+            Encoder.WriteUInt(buffer, first, true);
+            Encoder.WriteUInt(buffer, last, true);
+            Encoder.WriteBoolean(buffer, settled, true);
+            Encoder.WriteObject(buffer, state, true);
+            Encoder.WriteBoolean(buffer, batchable, true);
         }
 
         /// <summary>
@@ -95,7 +144,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "disposition",
                 new object[] { "role", "first", "last", "settled", "state", "batchable" },
-                this.Fields);
+                new object[] { role, first, last, settled, state, batchable });
 #else
             return base.ToString();
 #endif

--- a/src/Framing/End.cs
+++ b/src/Framing/End.cs
@@ -32,13 +32,27 @@ namespace Amqp.Framing
         {
         }
 
+        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return (Error)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.error; }
+            set { this.error = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.error = (Error)Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, error, true);
         }
 
         /// <summary>
@@ -50,7 +64,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "end",
                 new object[] { "error" },
-                this.Fields);
+                new object[] { error });
 #else
             return base.ToString();
 #endif

--- a/src/Framing/End.cs
+++ b/src/Framing/End.cs
@@ -24,6 +24,8 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class End : DescribedList
     {
+        Error error;
+
         /// <summary>
         /// Initializes an end object.
         /// </summary>
@@ -32,27 +34,39 @@ namespace Amqp.Framing
         {
         }
 
-        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return this.error; }
-            set { this.error = value; }
+            get { return this.GetField(0, this.error); }
+            set { this.SetField(0, ref this.error, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.error = (Error)Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.error);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, error, true);
+            switch (index)
+            {
+                case 0:
+                    this.error = (Error)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Framing/Error.cs
+++ b/src/Framing/Error.cs
@@ -44,31 +44,59 @@ namespace Amqp.Framing
             this.Condition = condition;
         }
 
+        private Symbol condition;
         /// <summary>
         /// Gets or sets a symbolic value indicating the error condition.
         /// </summary>
         public Symbol Condition
         {
-            get { return (Symbol)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.condition; }
+            set { this.condition = value; }
         }
 
+        private string description;
         /// <summary>
         /// Gets or sets the descriptive text about the error condition.
         /// </summary>
         public string Description
         {
-            get { return (string)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.description; }
+            set { this.description = value; }
         }
 
+        private Fields info;
         /// <summary>
         /// Gets or sets the map carrying information about the error condition.
         /// </summary>
         public Fields Info
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 2); }
-            set { this.Fields[2] = value; }
+            get { return this.info; }
+            set { this.info = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.condition = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.description = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.info = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteSymbol(buffer, condition, true);
+            Encoder.WriteString(buffer, description, true);
+            Encoder.WriteMap(buffer, info, true);
         }
 
 #if TRACE
@@ -81,7 +109,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "error",
                 new object[] { "condition", "description", "fields" },
-                this.Fields);
+                new object[] { condition, description, info });
         }
 #endif
     }

--- a/src/Framing/Flow.cs
+++ b/src/Framing/Flow.cs
@@ -24,6 +24,18 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Flow : DescribedList
     {
+        uint nextIncomingId;
+        uint incomingWindow;
+        uint nextOutgoingId;
+        uint outgoingWindow;
+        uint handle;
+        uint deliveryCount;
+        uint linkCredit;
+        uint available;
+        bool drain;
+        bool echo;
+        Fields properties;
+
         /// <summary>
         /// Initializes a flow object.
         /// </summary>
@@ -37,192 +49,194 @@ namespace Amqp.Framing
         /// </summary>
         public bool HasHandle
         {
-            get { return this.handle != null; }
+            get { return this.HasField(4); }
         }
 
-        private uint? nextIncomingId;
         /// <summary>
         /// Gets or sets the next-incoming-id field. 
         /// </summary>
         public uint NextIncomingId
         {
-            get { return this.nextIncomingId == null ? uint.MinValue : this.nextIncomingId.Value; }
-            set { this.nextIncomingId = value; }
+            get { return this.GetField(0, this.nextIncomingId, uint.MinValue); }
+            set { this.SetField(0, ref this.nextIncomingId, value); }
         }
 
-        private uint? incomingWindow;
         /// <summary>
         /// Gets or sets the incoming-window field. 
         /// </summary>
         public uint IncomingWindow
         {
-            get { return this.incomingWindow == null ? uint.MaxValue : this.incomingWindow.Value; }
-            set { this.incomingWindow = value; }
+            get { return this.GetField(1, this.incomingWindow, uint.MaxValue); }
+            set { this.SetField(1, ref this.incomingWindow, value); }
         }
 
-        private uint? nextOutgoingId;
         /// <summary>
         /// Gets or sets the next-outgoing-id field. 
         /// </summary>
         public uint NextOutgoingId
         {
-            get { return this.nextOutgoingId == null ? uint.MinValue : this.nextOutgoingId.Value; }
-            set { this.nextOutgoingId = value; }
+            get { return this.GetField(2, this.nextOutgoingId, uint.MinValue); }
+            set { this.SetField(2, ref this.nextOutgoingId, value); }
         }
 
-        private uint? outgoingWindow;
         /// <summary>
         /// Gets or sets the outgoing-window field.
         /// </summary>
         public uint OutgoingWindow
         {
-            get { return this.outgoingWindow == null ? uint.MaxValue : this.outgoingWindow.Value; }
-            set { this.outgoingWindow = value; }
+            get { return this.GetField(3, this.outgoingWindow, uint.MaxValue); }
+            set { this.SetField(3, ref this.outgoingWindow, value); }
         }
 
-        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.handle == null ? uint.MaxValue : this.handle.Value; }
-            set { this.handle = value; }
+            get { return this.GetField(4, this.handle, uint.MaxValue); }
+            set { this.SetField(4, ref this.handle, value); }
         }
 
-        private uint? deliveryCount;
         /// <summary>
         /// Gets or sets the delivery-count field.
         /// </summary>
         public uint DeliveryCount
         {
-            get { return this.deliveryCount == null ? uint.MinValue : this.deliveryCount.Value; }
-            set { this.deliveryCount = value; }
+            get { return this.GetField(5, this.deliveryCount, uint.MinValue); }
+            set { this.SetField(5, ref this.deliveryCount, value); }
         }
 
-        private uint? linkCredit;
         /// <summary>
         /// Gets or sets the link-credit field. 
         /// </summary>
         public uint LinkCredit
         {
-            get { return this.linkCredit == null ? uint.MinValue : this.linkCredit.Value; }
-            set { this.linkCredit = value; }
+            get { return this.GetField(6, this.linkCredit, uint.MinValue); }
+            set { this.SetField(6, ref this.linkCredit, value); }
         }
 
-        private uint? available;
         /// <summary>
         /// Gets or sets the available field.
         /// </summary>
         public uint Available
         {
-            get { return this.available == null ? uint.MinValue : this.available.Value; }
-            set { this.available = value; }
+            get { return this.GetField(7, this.available, uint.MinValue); }
+            set { this.SetField(7, ref this.available, value); }
         }
 
-        private bool? drain;
         /// <summary>
         /// Gets or sets the drain field.
         /// </summary>
         public bool Drain
         {
-            get { return this.drain == null ? false : this.drain.Value; }
-            set { this.drain = value; }
+            get { return this.GetField(8, this.drain, false); }
+            set { this.SetField(8, ref this.drain, value); }
         }
 
-        private bool? echo;
         /// <summary>
         /// Gets or sets the echo field.
         /// </summary>
         public bool Echo
         {
-            get { return this.echo == null ? false : this.echo.Value; }
-            set { this.echo = value; }
+            get { return this.GetField(9, this.echo, false); }
+            set { this.SetField(9, ref this.echo, value); }
         }
 
-        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return this.properties; }
-            set { this.properties = value; }
+            get { return this.GetField(10, this.properties); }
+            set { this.SetField(10, ref this.properties, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.nextIncomingId = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.incomingWindow = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.nextOutgoingId = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.outgoingWindow = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.handle = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.deliveryCount = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.linkCredit = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.available = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.drain = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.echo = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.properties = Encoder.ReadFields(buffer);
+                case 0:
+                    Encoder.WriteUInt(buffer, this.nextIncomingId, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.incomingWindow, true);
+                    break;
+                case 2:
+                    Encoder.WriteUInt(buffer, this.nextOutgoingId, true);
+                    break;
+                case 3:
+                    Encoder.WriteUInt(buffer, this.outgoingWindow, true);
+                    break;
+                case 4:
+                    Encoder.WriteUInt(buffer, this.handle, true);
+                    break;
+                case 5:
+                    Encoder.WriteUInt(buffer, this.deliveryCount, true);
+                    break;
+                case 6:
+                    Encoder.WriteUInt(buffer, this.linkCredit, true);
+                    break;
+                case 7:
+                    Encoder.WriteUInt(buffer, this.available, true);
+                    break;
+                case 8:
+                    Encoder.WriteBoolean(buffer, this.drain, true);
+                    break;
+                case 9:
+                    Encoder.WriteBoolean(buffer, this.echo, true);
+                    break;
+                case 10:
+                    Encoder.WriteMap(buffer, this.properties, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteUInt(buffer, nextIncomingId, true);
-            Encoder.WriteUInt(buffer, incomingWindow, true);
-            Encoder.WriteUInt(buffer, nextOutgoingId, true);
-            Encoder.WriteUInt(buffer, outgoingWindow, true);
-            Encoder.WriteUInt(buffer, handle, true);
-            Encoder.WriteUInt(buffer, deliveryCount, true);
-            Encoder.WriteUInt(buffer, linkCredit, true);
-            Encoder.WriteUInt(buffer, available, true);
-            Encoder.WriteBoolean(buffer, drain, true);
-            Encoder.WriteBoolean(buffer, echo, true);
-            Encoder.WriteMap(buffer, properties, true);
+            switch (index)
+            {
+                case 0:
+                    this.nextIncomingId = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 1:
+                    this.incomingWindow = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.nextOutgoingId = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 3:
+                    this.outgoingWindow = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 4:
+                    this.handle = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 5:
+                    this.deliveryCount = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 6:
+                    this.linkCredit = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 7:
+                    this.available = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 8:
+                    this.drain = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 9:
+                    this.echo = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 10:
+                    this.properties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>

--- a/src/Framing/Flow.cs
+++ b/src/Framing/Flow.cs
@@ -37,106 +37,190 @@ namespace Amqp.Framing
         /// </summary>
         public bool HasHandle
         {
-            get { return this.Fields[4] != null; }
+            get { return this.handle != null; }
         }
 
+        private uint? nextIncomingId;
         /// <summary>
         /// Gets or sets the next-incoming-id field. 
         /// </summary>
         public uint NextIncomingId
         {
-            get { return this.Fields[0] == null ? uint.MinValue : (uint)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.nextIncomingId == null ? uint.MinValue : this.nextIncomingId.Value; }
+            set { this.nextIncomingId = value; }
         }
 
+        private uint? incomingWindow;
         /// <summary>
         /// Gets or sets the incoming-window field. 
         /// </summary>
         public uint IncomingWindow
         {
-            get { return this.Fields[1] == null ? uint.MaxValue : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.incomingWindow == null ? uint.MaxValue : this.incomingWindow.Value; }
+            set { this.incomingWindow = value; }
         }
 
+        private uint? nextOutgoingId;
         /// <summary>
         /// Gets or sets the next-outgoing-id field. 
         /// </summary>
         public uint NextOutgoingId
         {
-            get { return this.Fields[2] == null ? uint.MinValue : (uint)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.nextOutgoingId == null ? uint.MinValue : this.nextOutgoingId.Value; }
+            set { this.nextOutgoingId = value; }
         }
 
+        private uint? outgoingWindow;
         /// <summary>
         /// Gets or sets the outgoing-window field.
         /// </summary>
         public uint OutgoingWindow
         {
-            get { return this.Fields[3] == null ? uint.MaxValue : (uint)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.outgoingWindow == null ? uint.MaxValue : this.outgoingWindow.Value; }
+            set { this.outgoingWindow = value; }
         }
 
+        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.Fields[4] == null ? uint.MaxValue : (uint)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.handle == null ? uint.MaxValue : this.handle.Value; }
+            set { this.handle = value; }
         }
 
+        private uint? deliveryCount;
         /// <summary>
         /// Gets or sets the delivery-count field.
         /// </summary>
         public uint DeliveryCount
         {
-            get { return this.Fields[5] == null ? uint.MinValue : (uint)this.Fields[5]; }
-            set { this.Fields[5] = value; }
+            get { return this.deliveryCount == null ? uint.MinValue : this.deliveryCount.Value; }
+            set { this.deliveryCount = value; }
         }
 
+        private uint? linkCredit;
         /// <summary>
         /// Gets or sets the link-credit field. 
         /// </summary>
         public uint LinkCredit
         {
-            get { return this.Fields[6] == null ? uint.MinValue : (uint)this.Fields[6]; }
-            set { this.Fields[6] = value; }
+            get { return this.linkCredit == null ? uint.MinValue : this.linkCredit.Value; }
+            set { this.linkCredit = value; }
         }
 
+        private uint? available;
         /// <summary>
         /// Gets or sets the available field.
         /// </summary>
         public uint Available
         {
-            get { return this.Fields[7] == null ? uint.MinValue : (uint)this.Fields[7]; }
-            set { this.Fields[7] = value; }
+            get { return this.available == null ? uint.MinValue : this.available.Value; }
+            set { this.available = value; }
         }
 
+        private bool? drain;
         /// <summary>
         /// Gets or sets the drain field.
         /// </summary>
         public bool Drain
         {
-            get { return this.Fields[8] == null ? false : (bool)this.Fields[8]; }
-            set { this.Fields[8] = value; }
+            get { return this.drain == null ? false : this.drain.Value; }
+            set { this.drain = value; }
         }
 
+        private bool? echo;
         /// <summary>
         /// Gets or sets the echo field.
         /// </summary>
         public bool Echo
         {
-            get { return this.Fields[9] == null ? false : (bool)this.Fields[9]; }
-            set { this.Fields[9] = value; }
+            get { return this.echo == null ? false : this.echo.Value; }
+            set { this.echo = value; }
         }
 
+        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 10); }
-            set { this.Fields[10] = value; }
+            get { return this.properties; }
+            set { this.properties = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.nextIncomingId = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.incomingWindow = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.nextOutgoingId = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.outgoingWindow = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.handle = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.deliveryCount = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.linkCredit = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.available = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.drain = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.echo = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.properties = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUInt(buffer, nextIncomingId, true);
+            Encoder.WriteUInt(buffer, incomingWindow, true);
+            Encoder.WriteUInt(buffer, nextOutgoingId, true);
+            Encoder.WriteUInt(buffer, outgoingWindow, true);
+            Encoder.WriteUInt(buffer, handle, true);
+            Encoder.WriteUInt(buffer, deliveryCount, true);
+            Encoder.WriteUInt(buffer, linkCredit, true);
+            Encoder.WriteUInt(buffer, available, true);
+            Encoder.WriteBoolean(buffer, drain, true);
+            Encoder.WriteBoolean(buffer, echo, true);
+            Encoder.WriteMap(buffer, properties, true);
         }
 
         /// <summary>
@@ -148,7 +232,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "flow",
                 new object[] { "next-in-id", "in-window", "next-out-id", "out-window", "handle", "delivery-count", "link-credit", "available", "drain", "echo", "properties" },
-                this.Fields);
+                new object[] { nextIncomingId, incomingWindow, nextOutgoingId, outgoingWindow, handle, deliveryCount, linkCredit, available, drain, echo, properties});
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Header.cs
+++ b/src/Framing/Header.cs
@@ -25,6 +25,12 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Header : DescribedList
     {
+        bool durable;
+        byte priority;
+        uint ttl;
+        bool firstAcquirer;
+        uint deliveryCount;
+
         /// <summary>
         /// Initializes a header object.
         /// </summary>
@@ -33,93 +39,101 @@ namespace Amqp.Framing
         {
         }
 
-        private bool? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public bool Durable
         {
-            get { return this.durable == null ? false : this.durable.Value; }
-            set { this.durable = value; }
+            get { return this.GetField(0, this.durable, false); }
+            set { this.SetField(0, ref this.durable, value); }
         }
 
-        private byte? priority;
         /// <summary>
         /// Gets or sets the priority field.
         /// </summary>
         public byte Priority
         {
-            get { return this.priority == null ? (byte)4 : this.priority.Value; }
-            set { this.priority = value; }
+            get { return this.GetField(1, this.priority, (byte)4); }
+            set { this.SetField(1, ref this.priority, value); }
         }
 
-        private uint? ttl;
         /// <summary>
         /// Gets or sets the ttl field.
         /// </summary>
         public uint Ttl
         {
-            get { return this.ttl == null ? uint.MaxValue : this.ttl.Value; }
-            set { this.ttl = value; }
+            get { return this.GetField(2, this.ttl, uint.MaxValue); }
+            set { this.SetField(2, ref this.ttl, value); }
         }
 
-        private bool? firstAcquirer;
         /// <summary>
         /// Gets or sets the first-acquirer field.
         /// </summary>
         public bool FirstAcquirer
         {
-            get { return this.firstAcquirer == null ? false : this.firstAcquirer.Value; }
-            set { this.firstAcquirer = value; }
+            get { return this.GetField(3, this.firstAcquirer, false); }
+            set { this.SetField(3, ref this.firstAcquirer, value); }
         }
 
-        private uint? deliveryCount;
         /// <summary>
         /// Gets or sets the delivery-count field.
         /// </summary>
         public uint DeliveryCount
         {
-            get { return this.deliveryCount == null ? uint.MinValue : this.deliveryCount.Value; }
-            set { this.deliveryCount = value; }
+            get { return this.GetField(4, this.deliveryCount, uint.MinValue); }
+            set { this.SetField(4, ref this.deliveryCount, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.durable = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.priority = Encoder.ReadUByte(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.ttl = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.firstAcquirer = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.deliveryCount = Encoder.ReadUInt(buffer);
+                case 0:
+                    Encoder.WriteBoolean(buffer, this.durable, true);
+                    break;
+                case 1:
+                    Encoder.WriteUByte(buffer, this.priority);
+                    break;
+                case 2:
+                    Encoder.WriteUInt(buffer, this.ttl, true);
+                    break;
+                case 3:
+                    Encoder.WriteBoolean(buffer, this.firstAcquirer, true);
+                    break;
+                case 4:
+                    Encoder.WriteUInt(buffer, this.deliveryCount, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBoolean(buffer, durable, true);
-            Encoder.WriteUByte(buffer, priority);
-            Encoder.WriteUInt(buffer, ttl, true);
-            Encoder.WriteBoolean(buffer, firstAcquirer, true);
-            Encoder.WriteUInt(buffer, deliveryCount, true);
+            switch (index)
+            {
+                case 0:
+                    this.durable = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 1:
+                    this.priority = Encoder.ReadUByte(buffer, formatCode);
+                    break;
+                case 2:
+                    this.ttl = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 3:
+                    this.firstAcquirer = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 4:
+                    this.deliveryCount = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current header object.

--- a/src/Framing/Header.cs
+++ b/src/Framing/Header.cs
@@ -33,49 +33,91 @@ namespace Amqp.Framing
         {
         }
 
+        private bool? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public bool Durable
         {
-            get { return this.Fields[0] == null ? false : (bool)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.durable == null ? false : this.durable.Value; }
+            set { this.durable = value; }
         }
 
+        private byte? priority;
         /// <summary>
         /// Gets or sets the priority field.
         /// </summary>
         public byte Priority
         {
-            get { return this.Fields[1] == null ? (byte)4 : (byte)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.priority == null ? (byte)4 : this.priority.Value; }
+            set { this.priority = value; }
         }
 
+        private uint? ttl;
         /// <summary>
         /// Gets or sets the ttl field.
         /// </summary>
         public uint Ttl
         {
-            get { return this.Fields[2] == null ? uint.MaxValue : (uint)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.ttl == null ? uint.MaxValue : this.ttl.Value; }
+            set { this.ttl = value; }
         }
 
+        private bool? firstAcquirer;
         /// <summary>
         /// Gets or sets the first-acquirer field.
         /// </summary>
         public bool FirstAcquirer
         {
-            get { return this.Fields[3] == null ? false : (bool)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.firstAcquirer == null ? false : this.firstAcquirer.Value; }
+            set { this.firstAcquirer = value; }
         }
 
+        private uint? deliveryCount;
         /// <summary>
         /// Gets or sets the delivery-count field.
         /// </summary>
         public uint DeliveryCount
         {
-            get { return this.Fields[4] == null ? uint.MinValue : (uint)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.deliveryCount == null ? uint.MinValue : this.deliveryCount.Value; }
+            set { this.deliveryCount = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.durable = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.priority = Encoder.ReadUByte(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.ttl = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.firstAcquirer = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.deliveryCount = Encoder.ReadUInt(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBoolean(buffer, durable, true);
+            Encoder.WriteUByte(buffer, priority);
+            Encoder.WriteUInt(buffer, ttl, true);
+            Encoder.WriteBoolean(buffer, firstAcquirer, true);
+            Encoder.WriteUInt(buffer, deliveryCount, true);
         }
 
 #if TRACE
@@ -88,7 +130,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "header",
                 new object[] { "durable", "priority", "ttl", "first-acquirer", "delivery-count" },
-                this.Fields);
+                new object[] {this.durable, this.priority, this.ttl, this.firstAcquirer, this.deliveryCount});
         }
 #endif
     }

--- a/src/Framing/Modified.cs
+++ b/src/Framing/Modified.cs
@@ -32,31 +32,59 @@ namespace Amqp.Framing
         {
         }
 
+        private bool? deliveryFailed;
         /// <summary>
         /// Gets or sets the delivery-failed field.
         /// </summary>
         public bool DeliveryFailed
         {
-            get { return this.Fields[0] == null ? false : (bool)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.deliveryFailed == null ? false : this.deliveryFailed.Value; }
+            set { this.deliveryFailed = value; }
         }
 
+        private bool? undeliverableHere;
         /// <summary>
         /// Gets or sets the undeliverable-here field.
         /// </summary>
         public bool UndeliverableHere
         {
-            get { return this.Fields[1] == null ? false : (bool)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.undeliverableHere == null ? false : this.undeliverableHere.Value; }
+            set { this.undeliverableHere = value; }
         }
 
+        private Fields messageAnnotations;
         /// <summary>
         /// Gets or sets the message-annotations field.
         /// </summary>
         public Fields MessageAnnotations
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 2); }
-            set { this.Fields[2] = value; }
+            get { return this.messageAnnotations; }
+            set { this.messageAnnotations = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.deliveryFailed = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.undeliverableHere = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.messageAnnotations = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBoolean(buffer, deliveryFailed, true);
+            Encoder.WriteBoolean(buffer, undeliverableHere, true);
+            Encoder.WriteMap(buffer, messageAnnotations, true);
         }
 
 #if TRACE
@@ -69,7 +97,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "modified",
                 new object[] { "delivery-failed", "undeliverable-here", "message-annotations" },
-                this.Fields);
+                new object[] { deliveryFailed, undeliverableHere, messageAnnotations });
         }
 #endif
     }

--- a/src/Framing/Open.cs
+++ b/src/Framing/Open.cs
@@ -32,94 +32,171 @@ namespace Amqp.Framing
         {
         }
 
+        private string containerId;
         /// <summary>
         /// Gets or sets the container-id field.
         /// </summary>
         public string ContainerId
         {
-            get { return (string)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.containerId; }
+            set { this.containerId = value; }
         }
 
+        private string hostName;
         /// <summary>
         /// Gets or sets the hostname field.
         /// </summary>
         public string HostName
         {
-            get { return (string)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.hostName; }
+            set { this.hostName = value; }
         }
 
+        private uint? maxFrameSize;
         /// <summary>
         /// Gets or sets the max-frame-size field.
         /// </summary>
         public uint MaxFrameSize
         {
-            get { return this.Fields[2] == null ? uint.MaxValue : (uint)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.maxFrameSize == null ? uint.MaxValue : this.maxFrameSize.Value; }
+            set { this.maxFrameSize = value; }
         }
 
+        private ushort? channelMax;
         /// <summary>
         /// Gets or sets the channel-max field.
         /// </summary>
         public ushort ChannelMax
         {
-            get { return this.Fields[3] == null ? ushort.MaxValue : (ushort)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.channelMax == null ? ushort.MaxValue : this.channelMax.Value; }
+            set { this.channelMax = value; }
         }
 
+        private uint? idleTimeOut;
         /// <summary>
         /// Gets or sets the idle-time-out field.
         /// </summary>
         public uint IdleTimeOut
         {
-            get { return this.Fields[4] == null ? 0 : (uint)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.idleTimeOut == null ? 0 : this.idleTimeOut.Value; }
+            set { this.idleTimeOut = value; }
         }
 
+        private object outgoingLocales;
         /// <summary>
         /// Gets or sets the outgoing-locales field.
         /// </summary>
         public Symbol[] OutgoingLocales
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 5); }
-            set { this.Fields[5] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.outgoingLocales); }
+            set { this.outgoingLocales = value; }
         }
 
+        private object incomingLocales;
         /// <summary>
         /// Gets or sets the incoming-locales field.
         /// </summary>
         public Symbol[] IncomingLocales
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 6); }
-            set { this.Fields[6] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.incomingLocales); }
+            set { this.incomingLocales = value; }
         }
 
+        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 7); }
-            set { this.Fields[7] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
+            set { this.offeredCapabilities = value; }
         }
 
+        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 8); }
-            set { this.Fields[8] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
+            set { this.desiredCapabilities = value; }
         }
 
+        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 9); }
-            set { this.Fields[9] = value; }
+            get { return this.properties; }
+            set { this.properties = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.containerId = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.hostName = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.maxFrameSize = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.channelMax = Encoder.ReadUShort(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.idleTimeOut = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.outgoingLocales = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.incomingLocales = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.offeredCapabilities = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.desiredCapabilities = Encoder.ReadObject(buffer);
+            }
+            
+            if (count-- > 0)
+            {
+                this.properties = Encoder.ReadFields(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteString(buffer, containerId, true);
+            Encoder.WriteString(buffer, hostName, true);
+            Encoder.WriteUInt(buffer, maxFrameSize, true);
+            Encoder.WriteUShort(buffer, channelMax);
+            Encoder.WriteUInt(buffer, idleTimeOut, true);
+            Encoder.WriteObject(buffer, outgoingLocales, true);
+            Encoder.WriteObject(buffer, incomingLocales, true);
+            Encoder.WriteObject(buffer, offeredCapabilities, true);
+            Encoder.WriteObject(buffer, desiredCapabilities, true);
+            Encoder.WriteMap(buffer, properties, true);
         }
 
 #if TRACE
@@ -132,7 +209,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "open",
                 new object[] { "container-id", "host-name", "max-frame-size", "channel-max", "idle-time-out", "outgoing-locales", "incoming-locales", "offered-capabilities", "desired-capabilities", "properties" },
-                this.Fields);
+                new object[] {containerId, hostName, maxFrameSize, channelMax, idleTimeOut, outgoingLocales, incomingLocales, offeredCapabilities, desiredCapabilities, properties});
         }
 #endif
     }

--- a/src/Framing/Open.cs
+++ b/src/Framing/Open.cs
@@ -24,6 +24,17 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Open : DescribedList
     {
+        string containerId;
+        string hostName;
+        uint maxFrameSize;
+        ushort channelMax;
+        uint idleTimeOut;
+        object outgoingLocales;
+        object incomingLocales;
+        object offeredCapabilities;
+        object desiredCapabilities;
+        Fields properties;
+
         /// <summary>
         /// Initializes the Open object.
         /// </summary>
@@ -32,171 +43,174 @@ namespace Amqp.Framing
         {
         }
 
-        private string containerId;
         /// <summary>
         /// Gets or sets the container-id field.
         /// </summary>
         public string ContainerId
         {
-            get { return this.containerId; }
-            set { this.containerId = value; }
+            get { return this.GetField(0, this.containerId); }
+            set { this.SetField(0, ref this.containerId, value); }
         }
 
-        private string hostName;
         /// <summary>
         /// Gets or sets the hostname field.
         /// </summary>
         public string HostName
         {
-            get { return this.hostName; }
-            set { this.hostName = value; }
+            get { return this.GetField(1, this.hostName); }
+            set { this.SetField(1, ref this.hostName, value); }
         }
 
-        private uint? maxFrameSize;
         /// <summary>
         /// Gets or sets the max-frame-size field.
         /// </summary>
         public uint MaxFrameSize
         {
-            get { return this.maxFrameSize == null ? uint.MaxValue : this.maxFrameSize.Value; }
-            set { this.maxFrameSize = value; }
+            get { return this.GetField(2, this.maxFrameSize, uint.MaxValue); }
+            set { this.SetField(2, ref this.maxFrameSize, value); }
         }
 
-        private ushort? channelMax;
         /// <summary>
         /// Gets or sets the channel-max field.
         /// </summary>
         public ushort ChannelMax
         {
-            get { return this.channelMax == null ? ushort.MaxValue : this.channelMax.Value; }
-            set { this.channelMax = value; }
+            get { return this.GetField(3, this.channelMax, ushort.MaxValue); }
+            set { this.SetField(3, ref this.channelMax, value); }
         }
 
-        private uint? idleTimeOut;
         /// <summary>
         /// Gets or sets the idle-time-out field.
         /// </summary>
         public uint IdleTimeOut
         {
-            get { return this.idleTimeOut == null ? 0 : this.idleTimeOut.Value; }
-            set { this.idleTimeOut = value; }
+            get { return this.GetField(4, this.idleTimeOut, 0u); }
+            set { this.SetField(4, ref this.idleTimeOut, value); }
         }
 
-        private object outgoingLocales;
         /// <summary>
         /// Gets or sets the outgoing-locales field.
         /// </summary>
         public Symbol[] OutgoingLocales
         {
-            get { return Codec.GetSymbolMultiple(ref this.outgoingLocales); }
-            set { this.outgoingLocales = value; }
+            get { return HasField(5) ? Codec.GetSymbolMultiple(ref this.outgoingLocales) : null; }
+            set { this.SetField(5, ref this.outgoingLocales, value); }
         }
 
-        private object incomingLocales;
         /// <summary>
         /// Gets or sets the incoming-locales field.
         /// </summary>
         public Symbol[] IncomingLocales
         {
-            get { return Codec.GetSymbolMultiple(ref this.incomingLocales); }
-            set { this.incomingLocales = value; }
+            get { return HasField(6) ? Codec.GetSymbolMultiple(ref this.incomingLocales) : null; }
+            set { this.SetField(6, ref this.incomingLocales, value); }
         }
 
-        private object offeredCapabilities;
         /// <summary>
         /// Gets or sets the offered-capabilities field.
         /// </summary>
         public Symbol[] OfferedCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.offeredCapabilities); }
-            set { this.offeredCapabilities = value; }
+            get { return HasField(7) ? Codec.GetSymbolMultiple(ref this.offeredCapabilities) : null; }
+            set { this.SetField(7, ref this.offeredCapabilities, value); }
         }
 
-        private object desiredCapabilities;
         /// <summary>
         /// Gets or sets the desired-capabilities field.
         /// </summary>
         public Symbol[] DesiredCapabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.desiredCapabilities); }
-            set { this.desiredCapabilities = value; }
+            get { return HasField(8) ? Codec.GetSymbolMultiple(ref this.desiredCapabilities) : null; }
+            set { this.SetField(8, ref this.desiredCapabilities, value); }
         }
 
-        private Fields properties;
         /// <summary>
         /// Gets or sets the properties field.
         /// </summary>
         public Fields Properties
         {
-            get { return this.properties; }
-            set { this.properties = value; }
+            get { return this.GetField(9, this.properties); }
+            set { this.SetField(9, ref this.properties, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.containerId = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.hostName = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.maxFrameSize = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.channelMax = Encoder.ReadUShort(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.idleTimeOut = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.outgoingLocales = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.incomingLocales = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.offeredCapabilities = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.desiredCapabilities = Encoder.ReadObject(buffer);
-            }
-            
-            if (count-- > 0)
-            {
-                this.properties = Encoder.ReadFields(buffer);
+                case 0:
+                    Encoder.WriteString(buffer, this.containerId, true);
+                    break;
+                case 1:
+                    Encoder.WriteString(buffer, this.hostName, true);
+                    break;
+                case 2:
+                    Encoder.WriteUInt(buffer, this.maxFrameSize, true);
+                    break;
+                case 3:
+                    Encoder.WriteUShort(buffer, this.channelMax);
+                    break;
+                case 4:
+                    Encoder.WriteUInt(buffer, this.idleTimeOut, true);
+                    break;
+                case 5:
+                    Encoder.WriteObject(buffer, this.outgoingLocales);
+                    break;
+                case 6:
+                    Encoder.WriteObject(buffer, this.incomingLocales);
+                    break;
+                case 7:
+                    Encoder.WriteObject(buffer, this.offeredCapabilities);
+                    break;
+                case 8:
+                    Encoder.WriteObject(buffer, this.desiredCapabilities);
+                    break;
+                case 9:
+                    Encoder.WriteMap(buffer, this.properties, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteString(buffer, containerId, true);
-            Encoder.WriteString(buffer, hostName, true);
-            Encoder.WriteUInt(buffer, maxFrameSize, true);
-            Encoder.WriteUShort(buffer, channelMax);
-            Encoder.WriteUInt(buffer, idleTimeOut, true);
-            Encoder.WriteObject(buffer, outgoingLocales, true);
-            Encoder.WriteObject(buffer, incomingLocales, true);
-            Encoder.WriteObject(buffer, offeredCapabilities, true);
-            Encoder.WriteObject(buffer, desiredCapabilities, true);
-            Encoder.WriteMap(buffer, properties, true);
+            switch (index)
+            {
+                case 0:
+                    this.containerId = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 1:
+                    this.hostName = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 2:
+                    this.maxFrameSize = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 3:
+                    this.channelMax = Encoder.ReadUShort(buffer, formatCode);
+                    break;
+                case 4:
+                    this.idleTimeOut = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 5:
+                    this.outgoingLocales = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 6:
+                    this.incomingLocales = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 7:
+                    this.offeredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 8:
+                    this.desiredCapabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 9:
+                    this.properties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Framing/Properties.cs
+++ b/src/Framing/Properties.cs
@@ -25,6 +25,20 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Properties : DescribedList
     {
+        object messageId;
+        byte[] userId;
+        string to;
+        string subject;
+        string replyTo;
+        object correlationId;
+        Symbol contentType;
+        Symbol contentEncoding;
+        DateTime absoluteExpiryTime;
+        DateTime creationTime;
+        string groupId;
+        uint groupSequence;
+        string replyToGroupId;
+
         /// <summary>
         /// Initializes a properties section.
         /// </summary>
@@ -33,7 +47,6 @@ namespace Amqp.Framing
         {
         }
 
-        private object messageId;
         /// <summary>
         /// Gets or sets the message-id field.
         /// </summary>
@@ -44,51 +57,46 @@ namespace Amqp.Framing
         /// </remarks>
         public string MessageId
         {
-            get { return (string)this.messageId; }
-            set { this.messageId = value; }
+            get { return (string)this.GetField(0, this.messageId); }
+            set { this.SetField(0, ref this.messageId, value); }
         }
 
-        private byte[] userId;
         /// <summary>
         /// Gets or sets the user-id field.
         /// </summary>
         public byte[] UserId
         {
-            get { return this.userId; }
-            set { this.userId = value; }
+            get { return this.GetField(1, this.userId); }
+            set { this.SetField(1, ref this.userId, value); }
         }
 
-        private string to;
         /// <summary>
         /// Gets or sets the to field.
         /// </summary>
         public string To
         {
-            get { return this.to; }
-            set { this.to = value; }
+            get { return this.GetField(2, this.to); }
+            set { this.SetField(2, ref this.to, value); }
         }
 
-        private string subject;
         /// <summary>
         /// Gets or sets the subject field.
         /// </summary>
         public string Subject
         {
-            get { return this.subject; }
-            set { this.subject = value; }
+            get { return this.GetField(3, this.subject); }
+            set { this.SetField(3, ref this.subject, value); }
         }
 
-        private string replyTo;
         /// <summary>
         /// Gets or sets the reply-to field.
         /// </summary>
         public string ReplyTo
         {
-            get { return this.replyTo; }
-            set { this.replyTo = value; }
+            get { return this.GetField(4, this.replyTo); }
+            set { this.SetField(4, ref this.replyTo, value); }
         }
 
-        private object correlationId;
         /// <summary>
         /// Gets or sets the correlation-id field.
         /// </summary>
@@ -99,163 +107,169 @@ namespace Amqp.Framing
         /// </remarks>
         public string CorrelationId
         {
-            get { return (string)this.correlationId; }
-            set { this.correlationId = value; }
+            get { return (string)this.GetField(5, this.correlationId); }
+            set { this.SetField(5, ref this.correlationId, value); }
         }
 
-        private Symbol contentType;
         /// <summary>
         /// Gets or sets the content-type field.
         /// </summary>
         public Symbol ContentType
         {
-            get { return this.contentType; }
-            set { this.contentType = value; }
+            get { return this.GetField(6, this.contentType); }
+            set { this.SetField(6, ref this.contentType, value); }
         }
 
-        private Symbol contentEncoding;
         /// <summary>
         /// Gets or sets the content-encoding field.
         /// </summary>
         public Symbol ContentEncoding
         {
-            get { return this.contentEncoding; }
-            set { this.contentEncoding = value; }
+            get { return this.GetField(7, this.contentEncoding); }
+            set { this.SetField(7, ref this.contentEncoding, value); }
         }
 
-        private DateTime? absoluteExpiryTime;
         /// <summary>
         /// Gets or sets the absolute-expiry-time field.
         /// </summary>
         public DateTime AbsoluteExpiryTime
         {
-            get { return this.absoluteExpiryTime == null ? DateTime.MinValue : this.absoluteExpiryTime.Value; }
-            set { this.absoluteExpiryTime = value; }
+            get { return this.GetField(8, this.absoluteExpiryTime, DateTime.MinValue); }
+            set { this.SetField(8, ref this.absoluteExpiryTime, value); }
         }
 
-        private DateTime? creationTime;
         /// <summary>
         /// Gets or sets the creation-time field.
         /// </summary>
         public DateTime CreationTime
         {
-            get { return this.creationTime == null ? DateTime.MinValue : this.creationTime.Value; }
-            set { this.creationTime = value; }
+            get { return this.GetField(9, this.creationTime, DateTime.MinValue); }
+            set { this.SetField(9, ref this.creationTime, value); }
         }
 
-        private string groupId;
         /// <summary>
         /// Gets or sets the group-id field.
         /// </summary>
         public string GroupId
         {
-            get { return this.groupId; }
-            set { this.groupId = value; }
+            get { return this.GetField(10, this.GetField(1, this.groupId)); }
+            set { this.SetField(10, ref this.groupId, value); }
         }
 
-        private uint? groupSequence;
         /// <summary>
         /// Gets or sets the group-sequence field.
         /// </summary>
         public uint GroupSequence
         {
-            get { return this.groupSequence == null ? uint.MinValue : this.groupSequence.Value; }
-            set { this.groupSequence = value; }
+            get { return this.GetField(11, this.groupSequence, uint.MinValue); }
+            set { this.SetField(11, ref this.groupSequence, value); }
         }
 
-        private string replyToGroupId;
         /// <summary>
         /// Gets or sets the reply-to-group-id field.
         /// </summary>
         public string ReplyToGroupId
         {
-            get { return this.replyToGroupId; }
-            set { this.replyToGroupId = value; }
+            get { return this.GetField(12, this.replyToGroupId); }
+            set { this.SetField(12, ref this.replyToGroupId, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.messageId = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.userId = Encoder.ReadBinary(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.to = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.subject = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.replyTo = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.correlationId = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.contentType = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.contentEncoding = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.absoluteExpiryTime = Encoder.ReadTimestamp(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.creationTime = Encoder.ReadTimestamp(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.groupId = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.groupSequence = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.replyToGroupId = Encoder.ReadString(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.messageId);
+                    break;
+                case 1:
+                    Encoder.WriteBinary(buffer, this.userId, true);
+                    break;
+                case 2:
+                    Encoder.WriteString(buffer, this.to, true);
+                    break;
+                case 3:
+                    Encoder.WriteString(buffer, this.subject, true);
+                    break;
+                case 4:
+                    Encoder.WriteString(buffer, this.replyTo, true);
+                    break;
+                case 5:
+                    Encoder.WriteObject(buffer, this.correlationId);
+                    break;
+                case 6:
+                    Encoder.WriteSymbol(buffer, this.contentType, true);
+                    break;
+                case 7:
+                    Encoder.WriteSymbol(buffer, this.contentEncoding, true);
+                    break;
+                case 8:
+                    Encoder.WriteTimestamp(buffer, this.absoluteExpiryTime);
+                    break;
+                case 9:
+                    Encoder.WriteTimestamp(buffer, this.creationTime);
+                    break;
+                case 10:
+                    Encoder.WriteString(buffer, this.groupId, true);
+                    break;
+                case 11:
+                    Encoder.WriteUInt(buffer, this.groupSequence, true);
+                    break;
+                case 12:
+                    Encoder.WriteString(buffer, this.replyToGroupId, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, messageId, true);
-            Encoder.WriteBinary(buffer, userId, true);
-            Encoder.WriteString(buffer, to, true);
-            Encoder.WriteString(buffer, subject, true);
-            Encoder.WriteString(buffer, replyTo, true);
-            Encoder.WriteObject(buffer, correlationId, true);
-            Encoder.WriteSymbol(buffer, contentType, true);
-            Encoder.WriteSymbol(buffer, contentEncoding, true);
-            Encoder.WriteTimestamp(buffer, absoluteExpiryTime);
-            Encoder.WriteTimestamp(buffer, creationTime);
-            Encoder.WriteString(buffer, groupId, true);
-            Encoder.WriteUInt(buffer, groupSequence, true);
-            Encoder.WriteString(buffer, replyToGroupId, true);
+            switch (index)
+            {
+                case 0:
+                    this.messageId = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 1:
+                    this.userId = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                case 2:
+                    this.to = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 3:
+                    this.subject = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 4:
+                    this.replyTo = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 5:
+                    this.correlationId = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 6:
+                    this.contentType = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 7:
+                    this.contentEncoding = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 8:
+                    this.absoluteExpiryTime = Encoder.ReadTimestamp(buffer, formatCode);
+                    break;
+                case 9:
+                    this.creationTime = Encoder.ReadTimestamp(buffer, formatCode);
+                    break;
+                case 10:
+                    this.groupId = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 11:
+                    this.groupSequence = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 12:
+                    this.replyToGroupId = Encoder.ReadString(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Framing/Properties.cs
+++ b/src/Framing/Properties.cs
@@ -152,7 +152,7 @@ namespace Amqp.Framing
         /// </summary>
         public string GroupId
         {
-            get { return this.GetField(10, this.GetField(1, this.groupId)); }
+            get { return this.GetField(10, this.groupId); }
             set { this.SetField(10, ref this.groupId, value); }
         }
 
@@ -279,7 +279,7 @@ namespace Amqp.Framing
         /// it is not set.</returns>
         public object GetMessageId()
         {
-            return ValidateIdentifier(this.messageId);
+            return this.GetField(0, ValidateIdentifier(this.messageId));
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Amqp.Framing
         /// <param name="id">The identifier object to set.</param>
         public void SetMessageId(object id)
         {
-            this.messageId = ValidateIdentifier(id);
+            this.SetField(0, ref this.messageId, ValidateIdentifier(id));
         }
 
         /// <summary>
@@ -299,7 +299,7 @@ namespace Amqp.Framing
         /// it is not set.</returns>
         public object GetCorrelationId()
         {
-            return ValidateIdentifier(this.correlationId);
+            return this.GetField(5, ValidateIdentifier(this.correlationId));
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace Amqp.Framing
         /// <param name="id">The identifier object to set.</param>
         public void SetCorrelationId(object id)
         {
-            this.correlationId = ValidateIdentifier(id);
+            this.SetField(5, ref this.correlationId, ValidateIdentifier(id));
         }
 
 #if TRACE

--- a/src/Framing/Properties.cs
+++ b/src/Framing/Properties.cs
@@ -33,6 +33,7 @@ namespace Amqp.Framing
         {
         }
 
+        private object messageId;
         /// <summary>
         /// Gets or sets the message-id field.
         /// </summary>
@@ -43,46 +44,51 @@ namespace Amqp.Framing
         /// </remarks>
         public string MessageId
         {
-            get { return (string)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return (string)this.messageId; }
+            set { this.messageId = value; }
         }
 
+        private byte[] userId;
         /// <summary>
         /// Gets or sets the user-id field.
         /// </summary>
         public byte[] UserId
         {
-            get { return (byte[])this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.userId; }
+            set { this.userId = value; }
         }
 
+        private string to;
         /// <summary>
         /// Gets or sets the to field.
         /// </summary>
         public string To
         {
-            get { return (string)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.to; }
+            set { this.to = value; }
         }
 
+        private string subject;
         /// <summary>
         /// Gets or sets the subject field.
         /// </summary>
         public string Subject
         {
-            get { return (string)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.subject; }
+            set { this.subject = value; }
         }
 
+        private string replyTo;
         /// <summary>
         /// Gets or sets the reply-to field.
         /// </summary>
         public string ReplyTo
         {
-            get { return (string)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.replyTo; }
+            set { this.replyTo = value; }
         }
 
+        private object correlationId;
         /// <summary>
         /// Gets or sets the correlation-id field.
         /// </summary>
@@ -93,71 +99,163 @@ namespace Amqp.Framing
         /// </remarks>
         public string CorrelationId
         {
-            get { return (string)this.Fields[5]; }
-            set { this.Fields[5] = value; }
+            get { return (string)this.correlationId; }
+            set { this.correlationId = value; }
         }
 
+        private Symbol contentType;
         /// <summary>
         /// Gets or sets the content-type field.
         /// </summary>
         public Symbol ContentType
         {
-            get { return (Symbol)this.Fields[6]; }
-            set { this.Fields[6] = value; }
+            get { return this.contentType; }
+            set { this.contentType = value; }
         }
 
+        private Symbol contentEncoding;
         /// <summary>
         /// Gets or sets the content-encoding field.
         /// </summary>
         public Symbol ContentEncoding
         {
-            get { return (Symbol)this.Fields[7]; }
-            set { this.Fields[7] = value; }
+            get { return this.contentEncoding; }
+            set { this.contentEncoding = value; }
         }
 
+        private DateTime? absoluteExpiryTime;
         /// <summary>
         /// Gets or sets the absolute-expiry-time field.
         /// </summary>
         public DateTime AbsoluteExpiryTime
         {
-            get { return this.Fields[8] == null ? DateTime.MinValue : (DateTime)this.Fields[8]; }
-            set { this.Fields[8] = value; }
+            get { return this.absoluteExpiryTime == null ? DateTime.MinValue : this.absoluteExpiryTime.Value; }
+            set { this.absoluteExpiryTime = value; }
         }
 
+        private DateTime? creationTime;
         /// <summary>
         /// Gets or sets the creation-time field.
         /// </summary>
         public DateTime CreationTime
         {
-            get { return this.Fields[9] == null ? DateTime.MinValue : (DateTime)this.Fields[9]; }
-            set { this.Fields[9] = value; }
+            get { return this.creationTime == null ? DateTime.MinValue : this.creationTime.Value; }
+            set { this.creationTime = value; }
         }
 
+        private string groupId;
         /// <summary>
         /// Gets or sets the group-id field.
         /// </summary>
         public string GroupId
         {
-            get { return (string)this.Fields[10]; }
-            set { this.Fields[10] = value; }
+            get { return this.groupId; }
+            set { this.groupId = value; }
         }
 
+        private uint? groupSequence;
         /// <summary>
         /// Gets or sets the group-sequence field.
         /// </summary>
         public uint GroupSequence
         {
-            get { return this.Fields[11] == null ? uint.MinValue : (uint)this.Fields[11]; }
-            set { this.Fields[11] = value; }
+            get { return this.groupSequence == null ? uint.MinValue : this.groupSequence.Value; }
+            set { this.groupSequence = value; }
         }
 
+        private string replyToGroupId;
         /// <summary>
         /// Gets or sets the reply-to-group-id field.
         /// </summary>
         public string ReplyToGroupId
         {
-            get { return (string)this.Fields[12]; }
-            set { this.Fields[12] = value; }
+            get { return this.replyToGroupId; }
+            set { this.replyToGroupId = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.messageId = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.userId = Encoder.ReadBinary(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.to = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.subject = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.replyTo = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.correlationId = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.contentType = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.contentEncoding = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.absoluteExpiryTime = Encoder.ReadTimestamp(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.creationTime = Encoder.ReadTimestamp(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.groupId = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.groupSequence = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.replyToGroupId = Encoder.ReadString(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, messageId, true);
+            Encoder.WriteBinary(buffer, userId, true);
+            Encoder.WriteString(buffer, to, true);
+            Encoder.WriteString(buffer, subject, true);
+            Encoder.WriteString(buffer, replyTo, true);
+            Encoder.WriteObject(buffer, correlationId, true);
+            Encoder.WriteSymbol(buffer, contentType, true);
+            Encoder.WriteSymbol(buffer, contentEncoding, true);
+            Encoder.WriteTimestamp(buffer, absoluteExpiryTime);
+            Encoder.WriteTimestamp(buffer, creationTime);
+            Encoder.WriteString(buffer, groupId, true);
+            Encoder.WriteUInt(buffer, groupSequence, true);
+            Encoder.WriteString(buffer, replyToGroupId, true);
         }
 
         /// <summary>
@@ -167,7 +265,7 @@ namespace Amqp.Framing
         /// it is not set.</returns>
         public object GetMessageId()
         {
-            return ValidateIdentifier(this.Fields[0]);
+            return ValidateIdentifier(this.messageId);
         }
 
         /// <summary>
@@ -177,7 +275,7 @@ namespace Amqp.Framing
         /// <param name="id">The identifier object to set.</param>
         public void SetMessageId(object id)
         {
-            this.Fields[0] = ValidateIdentifier(id);
+            this.messageId = ValidateIdentifier(id);
         }
 
         /// <summary>
@@ -187,7 +285,7 @@ namespace Amqp.Framing
         /// it is not set.</returns>
         public object GetCorrelationId()
         {
-            return ValidateIdentifier(this.Fields[5]);
+            return ValidateIdentifier(this.correlationId);
         }
 
         /// <summary>
@@ -197,7 +295,7 @@ namespace Amqp.Framing
         /// <param name="id">The identifier object to set.</param>
         public void SetCorrelationId(object id)
         {
-            this.Fields[5] = ValidateIdentifier(id);
+            this.correlationId = ValidateIdentifier(id);
         }
 
 #if TRACE
@@ -210,7 +308,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "properties",
                 new object[] { "message-id", "user-id", "to", "subject", "reply-to", "correlation-id", "content-type", "content-encoding", "absolute-expiry-time", "creation-time", "group-id", "group-sequence", "reply-to-group-id" },
-                this.Fields);
+                new object[] {messageId, userId, to, subject, replyTo, correlationId, contentType, contentEncoding, absoluteExpiryTime, creationTime, groupId, groupSequence, replyToGroupId });
         }
 #endif
 

--- a/src/Framing/Received.cs
+++ b/src/Framing/Received.cs
@@ -26,16 +26,37 @@ namespace Amqp.Framing
         {
         }
 
+        private uint? sectionNumber;
         public uint SectionNumber
         {
-            get { return this.Fields[0] == null ? uint.MinValue : (uint)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.sectionNumber == null ? uint.MinValue : this.sectionNumber.Value; }
+            set { this.sectionNumber = value; }
         }
 
+        private ulong? sectionOffset;
         public ulong SectionOffset
         {
-            get { return this.Fields[1] == null ? ulong.MinValue : (ulong)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.sectionOffset == null ? ulong.MinValue : this.sectionOffset.Value; }
+            set { this.sectionOffset = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.sectionNumber = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.sectionOffset = Encoder.ReadULong(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUInt(buffer, sectionNumber, true);
+            Encoder.WriteULong(buffer, sectionOffset, true);
         }
 
         public override string ToString()
@@ -44,7 +65,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "received",
                 new object[] { "section-number", "section-offset" },
-                this.Fields);
+                new object[] { sectionNumber, sectionOffset });
 #else
             return base.ToString();
 #endif

--- a/src/Framing/Rejected.cs
+++ b/src/Framing/Rejected.cs
@@ -32,13 +32,27 @@ namespace Amqp.Framing
         {
         }
 
+        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return (Error)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.error; }
+            set { this.error = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.error = (Error)Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, Error, true);
         }
 
 #if TRACE
@@ -51,7 +65,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "rejected",
                 new object[] { "error" },
-                this.Fields);
+                new object[] { error });
         }
 #endif
     }

--- a/src/Framing/Rejected.cs
+++ b/src/Framing/Rejected.cs
@@ -24,6 +24,8 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Rejected : Outcome
     {
+        Error error;
+
         /// <summary>
         /// Initializes a rejected object.
         /// </summary>
@@ -32,27 +34,39 @@ namespace Amqp.Framing
         {
         }
 
-        private Error error;
         /// <summary>
         /// Gets or sets the error field.
         /// </summary>
         public Error Error
         {
-            get { return this.error; }
-            set { this.error = value; }
+            get { return this.GetField(0, this.error); }
+            set { this.SetField(0, ref this.error, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.error = (Error)Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.error);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, Error, true);
+            switch (index)
+            {
+                case 0:
+                    this.error = (Error)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Framing/Released.cs
+++ b/src/Framing/Released.cs
@@ -42,7 +42,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "released",
                 new object[0],
-                this.Fields);
+                new object[0]);
         }
 #endif
     }

--- a/src/Framing/Released.cs
+++ b/src/Framing/Released.cs
@@ -31,6 +31,16 @@ namespace Amqp.Framing
             : base(Codec.Released, 0)
         {
         }
+        
+        internal override void WriteField(ByteBuffer buffer, int index)
+        {
+            Fx.Assert(false, "Invalid field index");
+        }
+
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
+        {
+            Fx.Assert(false, "Invalid field index");
+        }
 
 #if TRACE
         /// <summary>

--- a/src/Framing/Source.cs
+++ b/src/Framing/Source.cs
@@ -33,103 +33,187 @@ namespace Amqp.Framing
         {
         }
 
+        private string address;
         /// <summary>
         /// Gets or sets the address field.
         /// </summary>
         public string Address
         {
-            get { return (string)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.address; }
+            set { this.address = value; }
         }
 
+        private uint? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public uint Durable
         {
-            get { return this.Fields[1] == null ? 0u : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.durable == null ? 0u : this.durable.Value; }
+            set { this.durable = value; }
         }
 
+        private Symbol expiryPolicy;
         /// <summary>
         /// Gets or sets the expiry-policy field.
         /// </summary>
         public Symbol ExpiryPolicy
         {
-            get { return (Symbol)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.expiryPolicy; }
+            set { this.expiryPolicy = value; }
         }
 
+        private uint? timeout;
         /// <summary>
         /// Gets or sets the timeout field.
         /// </summary>
         public uint Timeout
         {
-            get { return this.Fields[3] == null ? 0u : (uint)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.timeout == null ? 0u : this.timeout.Value; }
+            set { this.timeout = value; }
         }
 
+        private bool? dynamic;
         /// <summary>
         /// Gets or sets the dynamic field.
         /// </summary>
         public bool Dynamic
         {
-            get { return this.Fields[4] == null ? false : (bool)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.dynamic == null ? false : this.dynamic.Value; }
+            set { this.dynamic = value; }
         }
 
+        private Fields dynamicNodeProperties;
         /// <summary>
         /// Gets or sets the dynamic-node-properties field.
         /// </summary>
         public Fields DynamicNodeProperties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 5); }
-            set { this.Fields[5] = value; }
+            get { return this.dynamicNodeProperties; }
+            set { this.dynamicNodeProperties = value; }
         }
 
+        private Symbol distributionMode;
         /// <summary>
         /// Gets or sets the distribution-mode field.
         /// </summary>
         public Symbol DistributionMode
         {
-            get { return (Symbol)this.Fields[6]; }
-            set { this.Fields[6] = value; }
+            get { return this.distributionMode; }
+            set { this.distributionMode = value; }
         }
 
+        private Map filterSet;
         /// <summary>
         /// Gets or sets the filter field.
         /// </summary>
         public Map FilterSet
         {
-            get { return (Map)this.Fields[7]; }
-            set { this.Fields[7] = value; }
+            get { return this.filterSet; }
+            set { this.filterSet = value; }
         }
 
+        private Outcome defaultOutcome;
         /// <summary>
         /// Gets or sets the default-outcome field.
         /// </summary>
         public Outcome DefaultOutcome
         {
-            get { return (Outcome)this.Fields[8]; }
-            set { this.Fields[8] = value; }
+            get { return this.defaultOutcome; }
+            set { this.defaultOutcome = value; }
         }
 
+        private object outcomes;
         /// <summary>
         /// Gets or sets the outcomes field.
         /// </summary>
         public Symbol[] Outcomes
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 9); }
-            set { this.Fields[9] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.outcomes); }
+            set { this.outcomes = value; }
         }
 
+        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 10); }
-            set { this.Fields[10] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
+            set { this.capabilities = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.address = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.durable = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.expiryPolicy = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.timeout = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.dynamic = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.dynamicNodeProperties = Encoder.ReadFields(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.distributionMode = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.filterSet = Encoder.ReadMap(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.defaultOutcome = (Outcome)Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.outcomes = Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.capabilities = Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteString(buffer, address, true);
+            Encoder.WriteUInt(buffer, durable, true);
+            Encoder.WriteSymbol(buffer, expiryPolicy, true);
+            Encoder.WriteUInt(buffer, timeout, true);
+            Encoder.WriteBoolean(buffer, dynamic, true);
+            Encoder.WriteMap(buffer, dynamicNodeProperties, true);
+            Encoder.WriteSymbol(buffer, distributionMode, true);
+            Encoder.WriteMap(buffer, filterSet, true);
+            Encoder.WriteObject(buffer, defaultOutcome, true);
+            Encoder.WriteObject(buffer, outcomes, true);
+            Encoder.WriteObject(buffer, capabilities, true);
         }
 
 #if TRACE
@@ -141,7 +225,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "source",
                 new object[] { "address", "durable", "expiry-policy", "timeout", "dynamic", "dynamic-node-properties", "distribution-mode", "filter", "default-outcome", "outcomes", "capabilities" },
-                this.Fields);
+                new object[] { address, durable, expiryPolicy, timeout, dynamic, dynamicNodeProperties, distributionMode, filterSet, defaultOutcome, outcomes, capabilities });
         }
 #endif
     }

--- a/src/Framing/Source.cs
+++ b/src/Framing/Source.cs
@@ -25,6 +25,18 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Source : DescribedList
     {
+        string address;
+        uint durable;
+        Symbol expiryPolicy;
+        uint timeout;
+        bool dynamic;
+        Fields dynamicNodeProperties;
+        Symbol distributionMode;
+        Map filterSet;
+        Outcome defaultOutcome;
+        object outcomes;
+        object capabilities;
+
         /// <summary>
         /// Initializes a source object.
         /// </summary>
@@ -33,187 +45,189 @@ namespace Amqp.Framing
         {
         }
 
-        private string address;
         /// <summary>
         /// Gets or sets the address field.
         /// </summary>
         public string Address
         {
-            get { return this.address; }
-            set { this.address = value; }
+            get { return this.GetField(0, this.address); }
+            set { this.SetField(0, ref this.address, value); }
         }
 
-        private uint? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public uint Durable
         {
-            get { return this.durable == null ? 0u : this.durable.Value; }
-            set { this.durable = value; }
+            get { return this.GetField(1, this.durable, 0u); }
+            set { this.SetField(1, ref this.durable, value); }
         }
 
-        private Symbol expiryPolicy;
         /// <summary>
         /// Gets or sets the expiry-policy field.
         /// </summary>
         public Symbol ExpiryPolicy
         {
-            get { return this.expiryPolicy; }
-            set { this.expiryPolicy = value; }
+            get { return this.GetField(2, this.expiryPolicy); }
+            set { this.SetField(2, ref this.expiryPolicy, value); }
         }
 
-        private uint? timeout;
         /// <summary>
         /// Gets or sets the timeout field.
         /// </summary>
         public uint Timeout
         {
-            get { return this.timeout == null ? 0u : this.timeout.Value; }
-            set { this.timeout = value; }
+            get { return this.GetField(3, this.timeout, 0u); }
+            set { this.SetField(3, ref this.timeout, value); }
         }
 
-        private bool? dynamic;
         /// <summary>
         /// Gets or sets the dynamic field.
         /// </summary>
         public bool Dynamic
         {
-            get { return this.dynamic == null ? false : this.dynamic.Value; }
-            set { this.dynamic = value; }
+            get { return this.GetField(4, this.dynamic, false); }
+            set { this.SetField(4, ref this.dynamic, value); }
         }
 
-        private Fields dynamicNodeProperties;
         /// <summary>
         /// Gets or sets the dynamic-node-properties field.
         /// </summary>
         public Fields DynamicNodeProperties
         {
-            get { return this.dynamicNodeProperties; }
-            set { this.dynamicNodeProperties = value; }
+            get { return this.GetField(5, this.dynamicNodeProperties); }
+            set { this.SetField(5, ref this.dynamicNodeProperties, value); }
         }
 
-        private Symbol distributionMode;
         /// <summary>
         /// Gets or sets the distribution-mode field.
         /// </summary>
         public Symbol DistributionMode
         {
-            get { return this.distributionMode; }
-            set { this.distributionMode = value; }
+            get { return this.GetField(6, this.distributionMode); }
+            set { this.SetField(6, ref this.distributionMode, value); }
         }
 
-        private Map filterSet;
         /// <summary>
         /// Gets or sets the filter field.
         /// </summary>
         public Map FilterSet
         {
-            get { return this.filterSet; }
-            set { this.filterSet = value; }
+            get { return this.GetField(7, this.filterSet); }
+            set { this.SetField(7, ref this.filterSet, value); }
         }
 
-        private Outcome defaultOutcome;
         /// <summary>
         /// Gets or sets the default-outcome field.
         /// </summary>
         public Outcome DefaultOutcome
         {
-            get { return this.defaultOutcome; }
-            set { this.defaultOutcome = value; }
+            get { return this.GetField(8, this.defaultOutcome); }
+            set { this.SetField(8, ref this.defaultOutcome, value); }
         }
 
-        private object outcomes;
         /// <summary>
         /// Gets or sets the outcomes field.
         /// </summary>
         public Symbol[] Outcomes
         {
-            get { return Codec.GetSymbolMultiple(ref this.outcomes); }
-            set { this.outcomes = value; }
+            get { return HasField(9) ? Codec.GetSymbolMultiple(ref this.outcomes) : null; }
+            set { this.SetField(9, ref this.outcomes, value); }
         }
 
-        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
-            set { this.capabilities = value; }
+            get { return HasField(10) ? Codec.GetSymbolMultiple(ref this.capabilities) : null; }
+            set { this.SetField(10, ref this.capabilities, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.address = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.durable = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.expiryPolicy = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.timeout = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.dynamic = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.dynamicNodeProperties = Encoder.ReadFields(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.distributionMode = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.filterSet = Encoder.ReadMap(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.defaultOutcome = (Outcome)Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.outcomes = Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.capabilities = Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteString(buffer, this.address, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.durable, true);
+                    break;
+                case 2:
+                    Encoder.WriteSymbol(buffer, this.expiryPolicy, true);
+                    break;
+                case 3:
+                    Encoder.WriteUInt(buffer, this.timeout, true);
+                    break;
+                case 4:
+                    Encoder.WriteBoolean(buffer, this.dynamic, true);
+                    break;
+                case 5:
+                    Encoder.WriteMap(buffer, this.dynamicNodeProperties, true);
+                    break;
+                case 6:
+                    Encoder.WriteSymbol(buffer, this.distributionMode, true);
+                    break;
+                case 7:
+                    Encoder.WriteMap(buffer, this.filterSet, true);
+                    break;
+                case 8:
+                    Encoder.WriteObject(buffer, this.defaultOutcome, true);
+                    break;
+                case 9:
+                    Encoder.WriteObject(buffer, this.outcomes, true);
+                    break;
+                case 10:
+                    Encoder.WriteObject(buffer, this.capabilities, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteString(buffer, address, true);
-            Encoder.WriteUInt(buffer, durable, true);
-            Encoder.WriteSymbol(buffer, expiryPolicy, true);
-            Encoder.WriteUInt(buffer, timeout, true);
-            Encoder.WriteBoolean(buffer, dynamic, true);
-            Encoder.WriteMap(buffer, dynamicNodeProperties, true);
-            Encoder.WriteSymbol(buffer, distributionMode, true);
-            Encoder.WriteMap(buffer, filterSet, true);
-            Encoder.WriteObject(buffer, defaultOutcome, true);
-            Encoder.WriteObject(buffer, outcomes, true);
-            Encoder.WriteObject(buffer, capabilities, true);
+            switch (index)
+            {
+                case 0:
+                    this.address = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 1:
+                    this.durable = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.expiryPolicy = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 3:
+                    this.timeout = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 4:
+                    this.dynamic = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 5:
+                    this.dynamicNodeProperties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                case 6:
+                    this.distributionMode = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 7:
+                    this.filterSet = Encoder.ReadMap(buffer, formatCode);
+                    break;
+                case 8:
+                    this.defaultOutcome = (Outcome)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 9:
+                    this.outcomes = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 10:
+                    this.capabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Framing/Target.cs
+++ b/src/Framing/Target.cs
@@ -33,67 +33,123 @@ namespace Amqp.Framing
         {
         }
 
+        private string address;
         /// <summary>
         /// Gets or sets the address field.
         /// </summary>
         public string Address
         {
-            get { return (string)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.address; }
+            set { this.address = value; }
         }
 
+        private uint? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public uint Durable
         {
-            get { return this.Fields[1] == null ? 0u : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.durable == null ? 0u : this.durable.Value; }
+            set { this.durable = value; }
         }
 
+        private Symbol expiryPolicy;
         /// <summary>
         /// Gets or sets the expiry-policy field.
         /// </summary>
         public Symbol ExpiryPolicy
         {
-            get { return (Symbol)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.expiryPolicy; }
+            set { this.expiryPolicy = value; }
         }
 
+        private uint? timeout;
         /// <summary>
         /// Gets or sets the timeout field.
         /// </summary>
         public uint Timeout
         {
-            get { return this.Fields[3] == null ? 0u : (uint)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.timeout == null ? 0u : this.timeout.Value; }
+            set { this.timeout = value; }
         }
 
+        private bool? dynamic;
         /// <summary>
         /// Gets or sets the dynamic field.
         /// </summary>
         public bool Dynamic
         {
-            get { return this.Fields[4] == null ? false : (bool)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.dynamic == null ? false : this.dynamic.Value; }
+            set { this.dynamic = value; }
         }
 
+        private Fields dynamicNodeProperties;
         /// <summary>
         /// Gets or sets the dynamic-node-properties field.
         /// </summary>
         public Fields DynamicNodeProperties
         {
-            get { return Amqp.Types.Fields.From(this.Fields, 5); }
-            set { this.Fields[5] = value; }
+            get { return this.dynamicNodeProperties; }
+            set { this.dynamicNodeProperties = value; }
         }
 
+        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 6); }
-            set { this.Fields[6] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
+            set { this.capabilities = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.address = Encoder.ReadString(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.durable = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.expiryPolicy = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.timeout = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.dynamic = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.dynamicNodeProperties = Encoder.ReadFields(buffer);
+            }
+            
+            if (count-- > 0)
+            {
+                this.capabilities = Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteString(buffer, address, true);
+            Encoder.WriteUInt(buffer, durable, true);
+            Encoder.WriteSymbol(buffer, expiryPolicy, true);
+            Encoder.WriteUInt(buffer, timeout, true);
+            Encoder.WriteBoolean(buffer, dynamic, true);
+            Encoder.WriteMap(buffer, dynamicNodeProperties, true);
+            Encoder.WriteObject(buffer, capabilities, true);
         }
 
 #if TRACE
@@ -106,7 +162,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "target",
                 new object[] { "address", "durable", "expiry-policy", "timeout", "dynamic", "dynamic-node-properties", "capabilities" },
-                this.Fields);
+                new object[] { address, durable, expiryPolicy, timeout, dynamic, dynamicNodeProperties, capabilities });
         }
 #endif
     }

--- a/src/Framing/Target.cs
+++ b/src/Framing/Target.cs
@@ -25,6 +25,14 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Target : DescribedList
     {
+        string address;
+        uint durable;
+        Symbol expiryPolicy;
+        uint timeout;
+        bool dynamic;
+        Fields dynamicNodeProperties;
+        object capabilities;
+
         /// <summary>
         /// Initializes a target object.
         /// </summary>
@@ -33,123 +41,129 @@ namespace Amqp.Framing
         {
         }
 
-        private string address;
         /// <summary>
         /// Gets or sets the address field.
         /// </summary>
         public string Address
         {
-            get { return this.address; }
-            set { this.address = value; }
+            get { return this.GetField(0, this.address); }
+            set { this.SetField(0, ref this.address, value); }
         }
 
-        private uint? durable;
         /// <summary>
         /// Gets or sets the durable field.
         /// </summary>
         public uint Durable
         {
-            get { return this.durable == null ? 0u : this.durable.Value; }
-            set { this.durable = value; }
+            get { return this.GetField(1, this.durable, 0u); }
+            set { this.SetField(1, ref this.durable, value); }
         }
 
-        private Symbol expiryPolicy;
         /// <summary>
         /// Gets or sets the expiry-policy field.
         /// </summary>
         public Symbol ExpiryPolicy
         {
-            get { return this.expiryPolicy; }
-            set { this.expiryPolicy = value; }
+            get { return this.GetField(2, this.expiryPolicy); }
+            set { this.SetField(2, ref this.expiryPolicy, value); }
         }
 
-        private uint? timeout;
         /// <summary>
         /// Gets or sets the timeout field.
         /// </summary>
         public uint Timeout
         {
-            get { return this.timeout == null ? 0u : this.timeout.Value; }
-            set { this.timeout = value; }
+            get { return this.GetField(3, this.timeout, 0u); }
+            set { this.SetField(3, ref this.timeout, value); }
         }
 
-        private bool? dynamic;
         /// <summary>
         /// Gets or sets the dynamic field.
         /// </summary>
         public bool Dynamic
         {
-            get { return this.dynamic == null ? false : this.dynamic.Value; }
-            set { this.dynamic = value; }
+            get { return this.GetField(4, this.dynamic, false); }
+            set { this.SetField(4, ref this.dynamic, value); }
         }
 
-        private Fields dynamicNodeProperties;
         /// <summary>
         /// Gets or sets the dynamic-node-properties field.
         /// </summary>
         public Fields DynamicNodeProperties
         {
-            get { return this.dynamicNodeProperties; }
-            set { this.dynamicNodeProperties = value; }
+            get { return this.GetField(5, this.dynamicNodeProperties); }
+            set { this.SetField(5, ref this.dynamicNodeProperties, value); }
         }
 
-        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
-            set { this.capabilities = value; }
+            get { return HasField(6) ? Codec.GetSymbolMultiple(ref this.capabilities) : null; }
+            set { this.SetField(6, ref this.capabilities, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.address = Encoder.ReadString(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.durable = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.expiryPolicy = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.timeout = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.dynamic = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.dynamicNodeProperties = Encoder.ReadFields(buffer);
-            }
-            
-            if (count-- > 0)
-            {
-                this.capabilities = Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteString(buffer, this.address, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.durable, true);
+                    break;
+                case 2:
+                    Encoder.WriteSymbol(buffer, this.expiryPolicy, true);
+                    break;
+                case 3:
+                    Encoder.WriteUInt(buffer, this.timeout, true);
+                    break;
+                case 4:
+                    Encoder.WriteBoolean(buffer, this.dynamic, true);
+                    break;
+                case 5:
+                    Encoder.WriteMap(buffer, this.dynamicNodeProperties, true);
+                    break;
+                case 6:
+                    Encoder.WriteObject(buffer, this.capabilities, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteString(buffer, address, true);
-            Encoder.WriteUInt(buffer, durable, true);
-            Encoder.WriteSymbol(buffer, expiryPolicy, true);
-            Encoder.WriteUInt(buffer, timeout, true);
-            Encoder.WriteBoolean(buffer, dynamic, true);
-            Encoder.WriteMap(buffer, dynamicNodeProperties, true);
-            Encoder.WriteObject(buffer, capabilities, true);
+            switch (index)
+            {
+                case 0:
+                    this.address = Encoder.ReadString(buffer, formatCode);
+                    break;
+                case 1:
+                    this.durable = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.expiryPolicy = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 3:
+                    this.timeout = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 4:
+                    this.dynamic = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 5:
+                    this.dynamicNodeProperties = Encoder.ReadFields(buffer, formatCode);
+                    break;
+                case 6:
+                    this.capabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Framing/Transfer.cs
+++ b/src/Framing/Transfer.cs
@@ -24,6 +24,18 @@ namespace Amqp.Framing
     /// </summary>
     public sealed class Transfer : DescribedList
     {
+        uint handle;
+        uint deliveryId;
+        byte[] deliveryTag;
+        uint messageFormat;
+        bool settled;
+        bool more;
+        ReceiverSettleMode rcvSettleMode;
+        DeliveryState state;
+        bool resume;
+        bool aborted;
+        bool batchable;
+
         /// <summary>
         /// Initializes an transfer object.
         /// </summary>
@@ -37,190 +49,192 @@ namespace Amqp.Framing
         /// </summary>
         public bool HasDeliveryId
         {
-            get { return this.deliveryId != null; }
+            get { return this.HasField(1); }
         }
 
-        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.handle == null ? uint.MaxValue : this.handle.Value; }
-            set { this.handle = value; }
+            get { return this.GetField(0, this.handle, uint.MaxValue); }
+            set { this.SetField(0, ref this.handle, value); }
         }
 
-        private uint? deliveryId;
         /// <summary>
         /// Gets or sets the delivery-id field. 
         /// </summary>
         public uint DeliveryId
         {
-            get { return this.deliveryId == null ? uint.MinValue : this.deliveryId.Value; }
-            set { this.deliveryId = value; }
+            get { return this.GetField(1, this.deliveryId, uint.MinValue); }
+            set { this.SetField(1, ref this.deliveryId, value); }
         }
 
-        private byte[] deliveryTag;
         /// <summary>
         /// Gets or sets the delivery-tag field.
         /// </summary>
         public byte[] DeliveryTag
         {
-            get { return this.deliveryTag; }
-            set { this.deliveryTag = value; }
+            get { return this.GetField(2, this.deliveryTag); }
+            set { this.SetField(2, ref this.deliveryTag, value); }
         }
 
-        private uint? messageFormat;
         /// <summary>
         /// Gets or sets the message-format field.
         /// </summary>
         public uint MessageFormat
         {
-            get { return this.messageFormat == null ? uint.MinValue : this.messageFormat.Value; }
-            set { this.messageFormat = value; }
+            get { return this.GetField(3, this.messageFormat, uint.MinValue); }
+            set { this.SetField(3, ref this.messageFormat, value); }
         }
 
-        private bool? settled;
         /// <summary>
         /// Gets or sets the settled field.
         /// </summary>
         public bool Settled
         {
-            get { return this.settled == null ? false : this.settled.Value; }
-            set { this.settled = value; }
+            get { return this.GetField(4, this.settled, false); }
+            set { this.SetField(4, ref this.settled, value); }
         }
 
-        private bool? more;
         /// <summary>
         /// Gets or sets the more field.
         /// </summary>
         public bool More
         {
-            get { return this.more == null ? false : this.more.Value; }
-            set { this.more = value; }
+            get { return this.GetField(5, this.more, false); }
+            set { this.SetField(5, ref this.more, value); }
         }
 
-        private ReceiverSettleMode? rcvSettleMode;
         /// <summary>
         /// Gets or sets the rcv-settle-mode field.
         /// </summary>
         public ReceiverSettleMode RcvSettleMode
         {
-            get { return this.rcvSettleMode == null ? ReceiverSettleMode.First : this.rcvSettleMode.Value; }
-            set { this.rcvSettleMode = value; }
+            get { return this.GetField(6, this.rcvSettleMode, ReceiverSettleMode.First); }
+            set { this.SetField(6, ref this.rcvSettleMode, value); }
         }
 
-        private DeliveryState state;
         /// <summary>
         /// Gets or sets the state field.
         /// </summary>
         public DeliveryState State
         {
-            get { return this.state; }
-            set { this.state = value; }
+            get { return this.GetField(7, this.state); }
+            set { this.SetField(7, ref this.state, value); }
         }
 
-        private bool? resume;
         /// <summary>
         /// Gets or sets the resume field.
         /// </summary>
         public bool Resume
         {
-            get { return this.resume == null ? false : this.resume.Value; }
-            set { this.resume = value; }
+            get { return this.GetField(8, this.resume, false); }
+            set { this.SetField(8, ref this.resume, value); }
         }
 
-        private bool? aborted;
         /// <summary>
         /// Gets or sets the aborted field.
         /// </summary>
         public bool Aborted
         {
-            get { return this.aborted == null ? false : this.aborted.Value; }
-            set { this.aborted = value; }
+            get { return this.GetField(9, this.aborted, false); }
+            set { this.SetField(9, ref this.aborted, value); }
         }
 
-        private bool? batchable;
         /// <summary>
         /// Gets or sets the batchable field.
         /// </summary>
         public bool Batchable
         {
-            get { return this.batchable == null ? false : this.batchable.Value; }
-            set { this.batchable = value; }
+            get { return this.GetField(10, this.batchable, false); }
+            set { this.SetField(10, ref this.batchable, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.handle = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.deliveryId = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.deliveryTag = Encoder.ReadBinary(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.messageFormat = Encoder.ReadUInt(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.settled = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.more = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.state = (DeliveryState)Encoder.ReadObject(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.resume = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.aborted = Encoder.ReadBoolean(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.batchable = Encoder.ReadBoolean(buffer);
+                case 0:
+                    Encoder.WriteUInt(buffer, this.handle, true);
+                    break;
+                case 1:
+                    Encoder.WriteUInt(buffer, this.deliveryId, true);
+                    break;
+                case 2:
+                    Encoder.WriteBinary(buffer, this.deliveryTag, true);
+                    break;
+                case 3:
+                    Encoder.WriteUInt(buffer, this.messageFormat, true);
+                    break;
+                case 4:
+                    Encoder.WriteBoolean(buffer, this.settled, true);
+                    break;
+                case 5:
+                    Encoder.WriteBoolean(buffer, this.more, true);
+                    break;
+                case 6:
+                    Encoder.WriteUByte(buffer, (byte)this.rcvSettleMode);
+                    break;
+                case 7:
+                    Encoder.WriteObject(buffer, this.state, true);
+                    break;
+                case 8:
+                    Encoder.WriteBoolean(buffer, this.resume, true);
+                    break;
+                case 9:
+                    Encoder.WriteBoolean(buffer, this.aborted, true);
+                    break;
+                case 10:
+                    Encoder.WriteBoolean(buffer, this.batchable, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteUInt(buffer, handle, true);
-            Encoder.WriteUInt(buffer, deliveryId, true);
-            Encoder.WriteBinary(buffer, deliveryTag, true);
-            Encoder.WriteUInt(buffer, messageFormat, true);
-            Encoder.WriteBoolean(buffer, settled, true);
-            Encoder.WriteBoolean(buffer, more, true);
-            Encoder.WriteUByte(buffer, (byte?)rcvSettleMode);
-            Encoder.WriteObject(buffer, state, true);
-            Encoder.WriteBoolean(buffer, resume, true);
-            Encoder.WriteBoolean(buffer, aborted, true);
-            Encoder.WriteBoolean(buffer, batchable, true);
+            switch (index)
+            {
+                case 0:
+                    this.handle = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 1:
+                    this.deliveryId = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 2:
+                    this.deliveryTag = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                case 3:
+                    this.messageFormat = Encoder.ReadUInt(buffer, formatCode);
+                    break;
+                case 4:
+                    this.settled = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 5:
+                    this.more = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 6:
+                    this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer, formatCode);
+                    break;
+                case 7:
+                    this.state = (DeliveryState)Encoder.ReadObject(buffer, formatCode);
+                    break;
+                case 8:
+                    this.resume = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 9:
+                    this.aborted = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                case 10:
+                    this.batchable = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Framing/Transfer.cs
+++ b/src/Framing/Transfer.cs
@@ -37,106 +37,190 @@ namespace Amqp.Framing
         /// </summary>
         public bool HasDeliveryId
         {
-            get { return this.Fields[1] != null; }
+            get { return this.deliveryId != null; }
         }
 
+        private uint? handle;
         /// <summary>
         /// Gets or sets the handle field.
         /// </summary>
         public uint Handle
         {
-            get { return this.Fields[0] == null ? uint.MaxValue : (uint)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.handle == null ? uint.MaxValue : this.handle.Value; }
+            set { this.handle = value; }
         }
 
+        private uint? deliveryId;
         /// <summary>
         /// Gets or sets the delivery-id field. 
         /// </summary>
         public uint DeliveryId
         {
-            get { return this.Fields[1] == null ? uint.MinValue : (uint)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.deliveryId == null ? uint.MinValue : this.deliveryId.Value; }
+            set { this.deliveryId = value; }
         }
 
+        private byte[] deliveryTag;
         /// <summary>
         /// Gets or sets the delivery-tag field.
         /// </summary>
         public byte[] DeliveryTag
         {
-            get { return (byte[])this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.deliveryTag; }
+            set { this.deliveryTag = value; }
         }
 
+        private uint? messageFormat;
         /// <summary>
         /// Gets or sets the message-format field.
         /// </summary>
         public uint MessageFormat
         {
-            get { return this.Fields[3] == null ? uint.MinValue : (uint)this.Fields[3]; }
-            set { this.Fields[3] = value; }
+            get { return this.messageFormat == null ? uint.MinValue : this.messageFormat.Value; }
+            set { this.messageFormat = value; }
         }
 
+        private bool? settled;
         /// <summary>
         /// Gets or sets the settled field.
         /// </summary>
         public bool Settled
         {
-            get { return this.Fields[4] == null ? false : (bool)this.Fields[4]; }
-            set { this.Fields[4] = value; }
+            get { return this.settled == null ? false : this.settled.Value; }
+            set { this.settled = value; }
         }
 
+        private bool? more;
         /// <summary>
         /// Gets or sets the more field.
         /// </summary>
         public bool More
         {
-            get { return this.Fields[5] == null ? false : (bool)this.Fields[5]; }
-            set { this.Fields[5] = value; }
+            get { return this.more == null ? false : this.more.Value; }
+            set { this.more = value; }
         }
 
+        private ReceiverSettleMode? rcvSettleMode;
         /// <summary>
         /// Gets or sets the rcv-settle-mode field.
         /// </summary>
         public ReceiverSettleMode RcvSettleMode
         {
-            get { return this.Fields[6] == null ? ReceiverSettleMode.First : (ReceiverSettleMode)this.Fields[6]; }
-            set { this.Fields[6] = (byte)value; }
+            get { return this.rcvSettleMode == null ? ReceiverSettleMode.First : this.rcvSettleMode.Value; }
+            set { this.rcvSettleMode = value; }
         }
 
+        private DeliveryState state;
         /// <summary>
         /// Gets or sets the state field.
         /// </summary>
         public DeliveryState State
         {
-            get { return (DeliveryState)this.Fields[7]; }
-            set { this.Fields[7] = value; }
+            get { return this.state; }
+            set { this.state = value; }
         }
 
+        private bool? resume;
         /// <summary>
         /// Gets or sets the resume field.
         /// </summary>
         public bool Resume
         {
-            get { return this.Fields[8] == null ? false : (bool)this.Fields[8]; }
-            set { this.Fields[8] = value; }
+            get { return this.resume == null ? false : this.resume.Value; }
+            set { this.resume = value; }
         }
 
+        private bool? aborted;
         /// <summary>
         /// Gets or sets the aborted field.
         /// </summary>
         public bool Aborted
         {
-            get { return this.Fields[9] == null ? false : (bool)this.Fields[9]; }
-            set { this.Fields[9] = value; }
+            get { return this.aborted == null ? false : this.aborted.Value; }
+            set { this.aborted = value; }
         }
 
+        private bool? batchable;
         /// <summary>
         /// Gets or sets the batchable field.
         /// </summary>
         public bool Batchable
         {
-            get { return this.Fields[10] == null ? false : (bool)this.Fields[10]; }
-            set { this.Fields[10] = value; }
+            get { return this.batchable == null ? false : this.batchable.Value; }
+            set { this.batchable = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.handle = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.deliveryId = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.deliveryTag = Encoder.ReadBinary(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.messageFormat = Encoder.ReadUInt(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.settled = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.more = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.rcvSettleMode = (ReceiverSettleMode)Encoder.ReadUByte(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.state = (DeliveryState)Encoder.ReadObject(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.resume = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.aborted = Encoder.ReadBoolean(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.batchable = Encoder.ReadBoolean(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUInt(buffer, handle, true);
+            Encoder.WriteUInt(buffer, deliveryId, true);
+            Encoder.WriteBinary(buffer, deliveryTag, true);
+            Encoder.WriteUInt(buffer, messageFormat, true);
+            Encoder.WriteBoolean(buffer, settled, true);
+            Encoder.WriteBoolean(buffer, more, true);
+            Encoder.WriteUByte(buffer, (byte?)rcvSettleMode);
+            Encoder.WriteObject(buffer, state, true);
+            Encoder.WriteBoolean(buffer, resume, true);
+            Encoder.WriteBoolean(buffer, aborted, true);
+            Encoder.WriteBoolean(buffer, batchable, true);
         }
 
         /// <summary>
@@ -149,7 +233,7 @@ namespace Amqp.Framing
             return this.GetDebugString(
                 "transfer",
                 new object[] { "handle", "delivery-id", "delivery-tag", "message-format", "settled", "more", "rcv-settle-mode", "state", "resume", "aborted", "batchable" },
-                this.Fields);
+                new object[] { handle, deliveryId, deliveryTag, messageFormat, settled, more, rcvSettleMode, state, resume, aborted, batchable });
 #else
             return base.ToString();
 #endif

--- a/src/Sasl/SaslChallenge.cs
+++ b/src/Sasl/SaslChallenge.cs
@@ -25,6 +25,8 @@ namespace Amqp.Sasl
     /// </summary>
     public class SaslChallenge : DescribedList
     {
+        byte[] challenge;
+
         /// <summary>
         /// Initializes the SASL challenge object.
         /// </summary>
@@ -33,27 +35,39 @@ namespace Amqp.Sasl
         {
         }
 
-        private byte[] challenge;
         /// <summary>
         /// Gets or sets the security challenge data.
         /// </summary>
         public byte[] Challenge
         {
-            get { return this.challenge; }
-            set { this.challenge = value; }
+            get { return this.GetField(0, this.challenge); }
+            set { this.SetField(0, ref this.challenge, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.challenge = Encoder.ReadBinary(buffer);
+                case 0:
+                    Encoder.WriteBinary(buffer, this.challenge, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBinary(buffer, challenge, true);
+            switch (index)
+            {
+                case 0:
+                    this.challenge = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Sasl/SaslChallenge.cs
+++ b/src/Sasl/SaslChallenge.cs
@@ -33,13 +33,27 @@ namespace Amqp.Sasl
         {
         }
 
+        private byte[] challenge;
         /// <summary>
         /// Gets or sets the security challenge data.
         /// </summary>
         public byte[] Challenge
         {
-            get { return (byte[])this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.challenge; }
+            set { this.challenge = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.challenge = Encoder.ReadBinary(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, challenge, true);
         }
 
 #if TRACE
@@ -51,7 +65,7 @@ namespace Amqp.Sasl
             return this.GetDebugString(
                 "sasl-challenge",
                 new object[] { "challenge" },
-                this.Fields);
+                new object[] { challenge });
         }
 #endif
     }

--- a/src/Sasl/SaslInit.cs
+++ b/src/Sasl/SaslInit.cs
@@ -33,31 +33,59 @@ namespace Amqp.Sasl
         {
         }
 
+        private Symbol mechanism;
         /// <summary>
         /// Gets or sets the selected security mechanism.
         /// </summary>
         public Symbol Mechanism
         {
-            get { return (Symbol)this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.mechanism; }
+            set { this.mechanism = value; }
         }
 
+        private byte[] initialResponse;
         /// <summary>
         /// Gets or sets the initial security response data.
         /// </summary>
         public byte[] InitialResponse
         {
-            get { return (byte[])this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.initialResponse; }
+            set { this.initialResponse = value; }
         }
 
+        private string hostName;
         /// <summary>
         /// Gets or sets the name of the target host.
         /// </summary>
         public string HostName
         {
-            get { return (string)this.Fields[2]; }
-            set { this.Fields[2] = value; }
+            get { return this.hostName; }
+            set { this.hostName = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.mechanism = Encoder.ReadSymbol(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.initialResponse = Encoder.ReadBinary(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.hostName = Encoder.ReadString(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteSymbol(buffer, mechanism, true);
+            Encoder.WriteBinary(buffer, initialResponse, true);
+            Encoder.WriteString(buffer, hostName, true);
         }
 
 #if TRACE
@@ -69,7 +97,7 @@ namespace Amqp.Sasl
             return this.GetDebugString(
                 "sasl-init",
                 new object[] { "mechanism", "initial-response", "hostname" },
-                new object[] { this.Fields[0], "...", this.Fields[2] });
+                new object[] { mechanism, "...", hostName });
         }
 #endif
     }

--- a/src/Sasl/SaslInit.cs
+++ b/src/Sasl/SaslInit.cs
@@ -25,6 +25,10 @@ namespace Amqp.Sasl
     /// </summary>
     public class SaslInit : DescribedList
     {
+        Symbol mechanism;
+        byte[] initialResponse;
+        string hostName;
+
         /// <summary>
         /// Initializes a SaslInit object.
         /// </summary>
@@ -33,59 +37,69 @@ namespace Amqp.Sasl
         {
         }
 
-        private Symbol mechanism;
         /// <summary>
         /// Gets or sets the selected security mechanism.
         /// </summary>
         public Symbol Mechanism
         {
-            get { return this.mechanism; }
-            set { this.mechanism = value; }
+            get { return this.GetField(0, this.mechanism); }
+            set { this.SetField(0, ref this.mechanism, value); }
         }
 
-        private byte[] initialResponse;
         /// <summary>
         /// Gets or sets the initial security response data.
         /// </summary>
         public byte[] InitialResponse
         {
-            get { return this.initialResponse; }
-            set { this.initialResponse = value; }
+            get { return this.GetField(1, this.initialResponse); }
+            set { this.SetField(1, ref this.initialResponse, value); }
         }
 
-        private string hostName;
         /// <summary>
         /// Gets or sets the name of the target host.
         /// </summary>
         public string HostName
         {
-            get { return this.hostName; }
-            set { this.hostName = value; }
+            get { return this.GetField(2, this.hostName); }
+            set { this.SetField(2, ref this.hostName, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.mechanism = Encoder.ReadSymbol(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.initialResponse = Encoder.ReadBinary(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.hostName = Encoder.ReadString(buffer);
+                case 0:
+                    Encoder.WriteSymbol(buffer, this.mechanism, true);
+                    break;
+                case 1:
+                    Encoder.WriteBinary(buffer, this.initialResponse, true);
+                    break;
+                case 2:
+                    Encoder.WriteString(buffer, this.hostName, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteSymbol(buffer, mechanism, true);
-            Encoder.WriteBinary(buffer, initialResponse, true);
-            Encoder.WriteString(buffer, hostName, true);
+            switch (index)
+            {
+                case 0:
+                    this.mechanism = Encoder.ReadSymbol(buffer, formatCode);
+                    break;
+                case 1:
+                    this.initialResponse = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                case 2:
+                    this.hostName = Encoder.ReadString(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Sasl/SaslMechanisms.cs
+++ b/src/Sasl/SaslMechanisms.cs
@@ -25,6 +25,8 @@ namespace Amqp.Sasl
     /// </summary>
     public class SaslMechanisms : DescribedList
     {
+        object saslServerMechanisms;
+
         /// <summary>
         /// Initializes a SaslMechanisms object.
         /// </summary>
@@ -33,29 +35,41 @@ namespace Amqp.Sasl
         {
         }
 
-        private object saslServerMechanisms;
         /// <summary>
         /// Gets or sets the available SASL mechanisms.
         /// </summary>
         public Symbol[] SaslServerMechanisms
         {
-            get { return Codec.GetSymbolMultiple(ref this.saslServerMechanisms); }
-            set { this.saslServerMechanisms = value; }
+            get { return HasField(0) ? Codec.GetSymbolMultiple(ref this.saslServerMechanisms) : null; }
+            set { this.SetField(0, ref this.saslServerMechanisms, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.saslServerMechanisms = Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.saslServerMechanisms, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, saslServerMechanisms, true);
+            switch (index)
+            {
+                case 0:
+                    this.saslServerMechanisms = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current SASL mechanisms object.

--- a/src/Sasl/SaslMechanisms.cs
+++ b/src/Sasl/SaslMechanisms.cs
@@ -33,13 +33,27 @@ namespace Amqp.Sasl
         {
         }
 
+        private object saslServerMechanisms;
         /// <summary>
         /// Gets or sets the available SASL mechanisms.
         /// </summary>
         public Symbol[] SaslServerMechanisms
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 0); }
-            set { this.Fields[0] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.saslServerMechanisms); }
+            set { this.saslServerMechanisms = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.saslServerMechanisms = Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, saslServerMechanisms, true);
         }
 
 #if TRACE
@@ -51,7 +65,7 @@ namespace Amqp.Sasl
             return this.GetDebugString(
                 "sasl-mechanisms",
                 new object[] { "sasl-server-mechanisms" },
-                this.Fields);
+                new object[] { saslServerMechanisms });
         }
 #endif
     }

--- a/src/Sasl/SaslOutcome.cs
+++ b/src/Sasl/SaslOutcome.cs
@@ -33,22 +33,43 @@ namespace Amqp.Sasl
         {
         }
 
+        private SaslCode code;
         /// <summary>
         /// Gets or sets the outcome of the sasl dialog.
         /// </summary>
         public SaslCode Code
         {
-            get { return (SaslCode)this.Fields[0]; }
-            set { this.Fields[0] = (byte)value; }
+            get { return this.code; }
+            set { this.code = value; }
         }
 
+        private byte[] additionalData;
         /// <summary>
         /// Gets or sets the additional data as specified in RFC-4422.
         /// </summary>
         public byte[] AdditionalData
         {
-            get { return (byte[])this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.additionalData; }
+            set { this.additionalData = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.code = (SaslCode)Encoder.ReadUByte(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.additionalData = Encoder.ReadBinary(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteUByte(buffer, (byte?)code);
+            Encoder.WriteBinary(buffer, additionalData, true);
         }
 
 #if TRACE
@@ -60,7 +81,7 @@ namespace Amqp.Sasl
             return this.GetDebugString(
                 "sasl-outcome",
                 new object[] { "code", "additional-data" },
-                this.Fields);
+                new object[] { code, additionalData });
         }
 #endif
     }

--- a/src/Sasl/SaslResponse.cs
+++ b/src/Sasl/SaslResponse.cs
@@ -25,6 +25,8 @@ namespace Amqp.Sasl
     /// </summary>
     public class SaslResponse : DescribedList
     {
+        byte[] response;
+
         /// <summary>
         /// Initializes a SaslResponse object.
         /// </summary>
@@ -33,29 +35,41 @@ namespace Amqp.Sasl
         {
         }
 
-        private byte[] response;
         /// <summary>
         /// Gets or sets the security response data.
         /// </summary>
         public byte[] Response
         {
-            get { return this.response; }
-            set { this.response = value; }
+            get { return this.GetField(0, this.response); }
+            set { this.SetField(0, ref this.response, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.response = Encoder.ReadBinary(buffer);
+                case 0:
+                    Encoder.WriteBinary(buffer, this.response, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBinary(buffer, response, true);
+            switch (index)
+            {
+                case 0:
+                    this.response = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current SASL response object.

--- a/src/Sasl/SaslResponse.cs
+++ b/src/Sasl/SaslResponse.cs
@@ -33,13 +33,27 @@ namespace Amqp.Sasl
         {
         }
 
+        private byte[] response;
         /// <summary>
         /// Gets or sets the security response data.
         /// </summary>
         public byte[] Response
         {
-            get { return (byte[])this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.response; }
+            set { this.response = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.response = Encoder.ReadBinary(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, response, true);
         }
 
 #if TRACE
@@ -51,7 +65,7 @@ namespace Amqp.Sasl
             return this.GetDebugString(
                 "sasl-response",
                 new object[] { "response" },
-                this.Fields);
+                new object[] { response });
         }
 #endif
     }

--- a/src/Transactions/Coordinator.cs
+++ b/src/Transactions/Coordinator.cs
@@ -25,6 +25,8 @@ namespace Amqp.Transactions
     /// </summary>
     public sealed class Coordinator : DescribedList
     {
+        object capabilities;
+
         /// <summary>
         /// Initializes a coordinator object.
         /// </summary>
@@ -33,29 +35,41 @@ namespace Amqp.Transactions
         {
         }
 
-        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
-            set { this.capabilities = value; }
+            get { return HasField(0) ? Codec.GetSymbolMultiple(ref this.capabilities) : null; }
+            set { this.SetField(0, ref this.capabilities, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.capabilities = Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.capabilities);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, capabilities, true);
+            switch (index)
+            {
+                case 0:
+                    this.capabilities = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current object.

--- a/src/Transactions/Coordinator.cs
+++ b/src/Transactions/Coordinator.cs
@@ -33,13 +33,27 @@ namespace Amqp.Transactions
         {
         }
 
+        private object capabilities;
         /// <summary>
         /// Gets or sets the capabilities field.
         /// </summary>
         public Symbol[] Capabilities
         {
-            get { return Codec.GetSymbolMultiple(this.Fields, 0); }
-            set { this.Fields[0] = value; }
+            get { return Codec.GetSymbolMultiple(ref this.capabilities); }
+            set { this.capabilities = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.capabilities = Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, capabilities, true);
         }
 
 #if TRACE
@@ -52,7 +66,7 @@ namespace Amqp.Transactions
             return this.GetDebugString(
                 "coordinator",
                 new object[] { "capabilities" },
-                this.Fields);
+                new object[] { capabilities });
         }
 #endif
     }

--- a/src/Transactions/Declare.cs
+++ b/src/Transactions/Declare.cs
@@ -25,6 +25,8 @@ namespace Amqp.Transactions
     /// </summary>
     public sealed class Declare : DescribedList
     {
+        object globalId;
+
         /// <summary>
         /// Initializes a declare object.
         /// </summary>
@@ -33,27 +35,39 @@ namespace Amqp.Transactions
         {
         }
 
-        private object globalId;
         /// <summary>
         /// Gets or sets the global-id field.
         /// </summary>
         public object GlobalId
         {
-            get { return this.globalId; }
-            set { this.globalId = value; }
+            get { return this.GetField(0, this.globalId); }
+            set { this.SetField(0, ref this.globalId, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.globalId = Encoder.ReadObject(buffer);
+                case 0:
+                    Encoder.WriteObject(buffer, this.globalId);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteObject(buffer, globalId, true);
+            switch (index)
+            {
+                case 0:
+                    this.globalId = Encoder.ReadObject(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Transactions/Declare.cs
+++ b/src/Transactions/Declare.cs
@@ -33,13 +33,27 @@ namespace Amqp.Transactions
         {
         }
 
+        private object globalId;
         /// <summary>
         /// Gets or sets the global-id field.
         /// </summary>
         public object GlobalId
         {
-            get { return this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.globalId; }
+            set { this.globalId = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.globalId = Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteObject(buffer, globalId, true);
         }
 
 #if TRACE
@@ -52,7 +66,7 @@ namespace Amqp.Transactions
             return this.GetDebugString(
                 "declare",
                 new object[] { "global-id" },
-                this.Fields);
+                new object[] { globalId });
         }
 #endif
     }

--- a/src/Transactions/Declared.cs
+++ b/src/Transactions/Declared.cs
@@ -25,6 +25,8 @@ namespace Amqp.Transactions
     /// </summary>
     public sealed class Declared : Outcome
     {
+        byte[] txnId;
+
         /// <summary>
         /// Initializes a declared object.
         /// </summary>
@@ -33,29 +35,41 @@ namespace Amqp.Transactions
         {
         }
 
-        private byte[] txnId;
         /// <summary>
         /// Gets or sets the txn-id field.
         /// </summary>
         public byte[] TxnId
         {
-            get { return this.txnId; }
-            set { this.txnId = value; }
+            get { return this.GetField(0, this.txnId); }
+            set { this.SetField(0, ref this.txnId, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.txnId = Encoder.ReadBinary(buffer);
+                case 0:
+                    Encoder.WriteBinary(buffer, this.txnId, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBinary(buffer, txnId, true);
+            switch (index)
+            {
+                case 0:
+                    this.txnId = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
-
+        
 #if TRACE
         /// <summary>
         /// Returns a string that represents the current object.

--- a/src/Transactions/Declared.cs
+++ b/src/Transactions/Declared.cs
@@ -33,13 +33,27 @@ namespace Amqp.Transactions
         {
         }
 
+        private byte[] txnId;
         /// <summary>
         /// Gets or sets the txn-id field.
         /// </summary>
         public byte[] TxnId
         {
-            get { return (byte[])this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.txnId; }
+            set { this.txnId = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.txnId = Encoder.ReadBinary(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, txnId, true);
         }
 
 #if TRACE
@@ -52,7 +66,7 @@ namespace Amqp.Transactions
             return this.GetDebugString(
                 "declared",
                 new object[] { "txn-id" },
-                this.Fields);
+                new object[] { txnId });
         }
 #endif
     }

--- a/src/Transactions/Discharge.cs
+++ b/src/Transactions/Discharge.cs
@@ -33,22 +33,43 @@ namespace Amqp.Transactions
         {
         }
 
+        private byte[] txnId;
         /// <summary>
         /// Gets or sets the txn-id field.
         /// </summary>
         public byte[] TxnId
         {
-            get { return (byte[])this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.txnId; }
+            set { this.txnId = value; }
         }
 
+        private bool? fail;
         /// <summary>
         /// Gets or sets the fail field.
         /// </summary>
         public bool Fail
         {
-            get { return this.Fields[1] == null ? false : (bool)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.fail == null ? false : this.fail.Value; }
+            set { this.fail = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.txnId = Encoder.ReadBinary(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.fail = Encoder.ReadBoolean(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, txnId, true);
+            Encoder.WriteBoolean(buffer, fail, true);
         }
 
 #if TRACE
@@ -61,7 +82,7 @@ namespace Amqp.Transactions
             return this.GetDebugString(
                 "discharge",
                 new object[] { "txn-id", "fail" },
-                this.Fields);
+                new object[] { txnId, fail });
         }
 #endif
     }

--- a/src/Transactions/Discharge.cs
+++ b/src/Transactions/Discharge.cs
@@ -25,6 +25,9 @@ namespace Amqp.Transactions
     /// </summary>
     public sealed class Discharge : DescribedList
     {
+        byte[] txnId;
+        bool fail;
+
         /// <summary>
         /// Initializes a discharge object.
         /// </summary>
@@ -33,43 +36,54 @@ namespace Amqp.Transactions
         {
         }
 
-        private byte[] txnId;
         /// <summary>
         /// Gets or sets the txn-id field.
         /// </summary>
         public byte[] TxnId
         {
-            get { return this.txnId; }
-            set { this.txnId = value; }
+            get { return this.GetField(0, this.txnId); }
+            set { this.SetField(0, ref this.txnId, value); }
         }
 
-        private bool? fail;
         /// <summary>
         /// Gets or sets the fail field.
         /// </summary>
         public bool Fail
         {
-            get { return this.fail == null ? false : this.fail.Value; }
-            set { this.fail = value; }
+            get { return this.GetField(1, this.fail, false); }
+            set { this.SetField(1, ref this.fail, value); }
         }
 
-        internal override void OnDecode(ByteBuffer buffer, int count)
+        internal override void WriteField(ByteBuffer buffer, int index)
         {
-            if (count-- > 0)
+            switch (index)
             {
-                this.txnId = Encoder.ReadBinary(buffer);
-            }
-
-            if (count-- > 0)
-            {
-                this.fail = Encoder.ReadBoolean(buffer);
+                case 0:
+                    Encoder.WriteBinary(buffer, this.txnId, true);
+                    break;
+                case 1:
+                    Encoder.WriteBoolean(buffer, this.fail, true);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
             }
         }
 
-        internal override void OnEncode(ByteBuffer buffer)
+        internal override void ReadField(ByteBuffer buffer, int index, byte formatCode)
         {
-            Encoder.WriteBinary(buffer, txnId, true);
-            Encoder.WriteBoolean(buffer, fail, true);
+            switch (index)
+            {
+                case 0:
+                    this.txnId = Encoder.ReadBinary(buffer, formatCode);
+                    break;
+                case 1:
+                    this.fail = Encoder.ReadBoolean(buffer, formatCode);
+                    break;
+                default:
+                    Fx.Assert(false, "Invalid field index");
+                    break;
+            }
         }
 
 #if TRACE

--- a/src/Transactions/TransactionalState.cs
+++ b/src/Transactions/TransactionalState.cs
@@ -33,22 +33,43 @@ namespace Amqp.Transactions
         {
         }
 
+        private byte[] txnId;
         /// <summary>
         /// Gets or sets the txn-id field.
         /// </summary>
         public byte[] TxnId
         {
-            get { return (byte[])this.Fields[0]; }
-            set { this.Fields[0] = value; }
+            get { return this.txnId; }
+            set { this.txnId = value; }
         }
 
+        private Outcome outcome;
         /// <summary>
         /// Gets or sets the outcome field.
         /// </summary>
         public Outcome Outcome
         {
-            get { return (Outcome)this.Fields[1]; }
-            set { this.Fields[1] = value; }
+            get { return this.outcome; }
+            set { this.outcome = value; }
+        }
+
+        internal override void OnDecode(ByteBuffer buffer, int count)
+        {
+            if (count-- > 0)
+            {
+                this.txnId = Encoder.ReadBinary(buffer);
+            }
+
+            if (count-- > 0)
+            {
+                this.outcome = (Outcome)Encoder.ReadObject(buffer);
+            }
+        }
+
+        internal override void OnEncode(ByteBuffer buffer)
+        {
+            Encoder.WriteBinary(buffer, txnId, true);
+            Encoder.WriteObject(buffer, outcome, true);
         }
 
 #if TRACE
@@ -61,7 +82,7 @@ namespace Amqp.Transactions
             return this.GetDebugString(
                 "txn-state",
                 new object[] { "txn-id", "outcome" },
-                this.Fields);
+                new object[] { txnId, outcome });
         }
 #endif
     }

--- a/src/Types/DescribedList.cs
+++ b/src/Types/DescribedList.cs
@@ -24,7 +24,8 @@ namespace Amqp.Types
     /// </summary>
     public abstract class DescribedList : RestrictedDescribed
     {
-        private readonly int fieldCount;
+        readonly int fieldCount;
+        int fields;
 
         /// <summary>
         /// Initializes the described list object.
@@ -34,43 +35,14 @@ namespace Amqp.Types
         protected DescribedList(Descriptor descriptor, int fieldCount)
             : base(descriptor)
         {
+            if (fieldCount > 32)
+            {
+                throw new NotSupportedException("Maximum number of fields allowed is 32.");
+            }
+
             this.fieldCount = fieldCount;
         }
         
-        internal override void DecodeValue(ByteBuffer buffer)
-        {
-            byte formatCode = Encoder.ReadFormatCode(buffer);
-            if (formatCode == FormatCode.Null)
-            {
-                return;
-            }
-
-            int size;
-            int count;
-            if (formatCode == FormatCode.List0)
-            {
-                size = count = 0;
-                return;
-            }
-
-            if (formatCode == FormatCode.List8)
-            {
-                size = AmqpBitConverter.ReadUByte(buffer);
-                count = AmqpBitConverter.ReadUByte(buffer);
-            }
-            else if (formatCode == FormatCode.List32)
-            {
-                size = (int)AmqpBitConverter.ReadUInt(buffer);
-                count = (int)AmqpBitConverter.ReadUInt(buffer);
-            }
-            else
-            {
-                throw Encoder.InvalidFormatCodeException(formatCode, buffer.Offset);
-            }
-
-            OnDecode(buffer, count);
-        }
-
         /// <summary>
         /// Examines the list to check if a field is set.
         /// </summary>
@@ -79,7 +51,7 @@ namespace Amqp.Types
         public bool HasField(int index)
         {
             this.CheckFieldIndex(index);
-            return this.fields[index] != null;
+            return (this.fields & (1 << index)) > 0;
         }
 
         /// <summary>
@@ -89,50 +61,81 @@ namespace Amqp.Types
         public void ResetField(int index)
         {
             this.CheckFieldIndex(index);
-            this.fields[index] = null;
+            this.fields &= ~(1 << index);
         }
 
-        /// <summary>
-        /// Decodes all properties from a ByteBuffer
-        /// </summary>
-        /// <param name="buffer">the ByteBuffer to read from</param>
-        /// <param name="count">the number of fields that are available for read</param>
-        internal virtual void OnDecode(ByteBuffer buffer, int count)
+        internal void SetField<T>(int index, ref T field, T value)
         {
+            this.fields |= (1 << index);
+            field = value;
         }
 
-        /// <summary>
-        /// Encodes all properties into a ByteBuffer
-        /// </summary>
-        /// <param name="buffer">the ByteBuffer to write to</param>
-        internal virtual void OnEncode(ByteBuffer buffer)
+        internal T GetField<T>(int index, T field, T defaultValue = default(T))
         {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
         }
+
+
+        internal override void DecodeValue(ByteBuffer buffer)
+        {
+            byte formatCode = Encoder.ReadFormatCode(buffer);
+            int size;
+            int count;
+            Encoder.ReadListCount(buffer, formatCode, out size, out count);
+            for (int i = 0; i < count; i++)
+            {
+                formatCode = Encoder.ReadFormatCode(buffer);
+                if (formatCode != FormatCode.Null)
+                {
+                    this.ReadField(buffer, i, formatCode);
+                    this.fields |= (1 << i);
+                }
+            }
+        }
+
+        internal abstract void WriteField(ByteBuffer buffer, int index);
+
+        internal abstract void ReadField(ByteBuffer buffer, int index, byte formatCode);
+        
 
         internal override void EncodeValue(ByteBuffer buffer)
         {
-            int pos = buffer.WritePos;
-            AmqpBitConverter.WriteUByte(buffer, 0);
-            AmqpBitConverter.WriteUInt(buffer, 0);
-            AmqpBitConverter.WriteUInt(buffer, 0);
-
-            OnEncode(buffer);
-
-            int size = buffer.WritePos - pos - 9;
-
-            if (size < byte.MaxValue && this.fieldCount <= byte.MaxValue)
+            int count = 0;
+            int temp = this.fields;
+            while (temp > 0)
             {
-                buffer.Buffer[pos] = FormatCode.List8;
-                buffer.Buffer[pos + 1] = (byte)(size + 1);
-                buffer.Buffer[pos + 2] = (byte)this.fieldCount;
-                Array.Copy(buffer.Buffer, pos + 9, buffer.Buffer, pos + 3, size);
-                buffer.Shrink(6);
+                count++;
+                temp <<= 1;
+            }
+
+            count = 32 - count;
+            if (count == 0)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.List0);
             }
             else
             {
-                buffer.Buffer[pos] = FormatCode.List32;
-                AmqpBitConverter.WriteInt(buffer.Buffer, pos + 1, size + 4);
-                AmqpBitConverter.WriteInt(buffer.Buffer, pos + 5, this.fieldCount);
+                int pos = buffer.WritePos;
+                AmqpBitConverter.WriteUByte(buffer, 0);
+                AmqpBitConverter.WriteULong(buffer, 0);
+                for (int i = 0; i < count; i++)
+                {
+                    if ((this.fields & (1 << i)) > 0)
+                    {
+                        this.WriteField(buffer, i);
+                    }
+                    else
+                    {
+                        AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                    }
+                }
+
+                Encoder.WriteListCount(buffer, pos, count, true);
             }
         }
         
@@ -174,10 +177,10 @@ namespace Amqp.Types
 
         void CheckFieldIndex(int index)
         {
-            if (index < 0 || index >= this.fields.Length)
+            if (index < 0 || index >= this.fieldCount)
             {
                 throw new ArgumentOutOfRangeException(Fx.Format("Field index is invalid. {0} has {1} fields.",
-                    this.GetType().Name, this.fields.Length));
+                    this.GetType().Name, this.fieldCount));
             }
         }
     }

--- a/src/Types/DescribedList.cs
+++ b/src/Types/DescribedList.cs
@@ -27,7 +27,7 @@ namespace Amqp.Types
     public abstract class DescribedList : RestrictedDescribed
     {
         readonly int fieldCount;
-        int fields;
+        int fields; // bitmask that stores an 'is null' flag for each field
 
         /// <summary>
         /// Initializes the described list object.

--- a/src/Types/DescribedList.cs
+++ b/src/Types/DescribedList.cs
@@ -18,6 +18,8 @@
 namespace Amqp.Types
 {
     using System;
+    using Amqp.Framing;
+    using Amqp.Sasl;
 
     /// <summary>
     /// The DescribedList class consist of a descriptor and an AMQP list.
@@ -64,6 +66,298 @@ namespace Amqp.Types
             this.fields &= ~(1 << index);
         }
 
+#if NETMF
+        #region non-generic NETMF setter / getter
+        internal void SetField(int index, ref uint field, uint value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref ushort field, ushort value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref bool field, bool value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref ulong field, ulong value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref byte field, byte value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref string field, string value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref byte[] field, byte[] value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref Outcome field, Outcome value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref Map field, Map value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref ReceiverSettleMode field, ReceiverSettleMode value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref SenderSettleMode field, SenderSettleMode value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref DeliveryState field, DeliveryState value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref Error field, Error value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref Fields field, Fields value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref DateTime field, DateTime value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref Symbol field, Symbol value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref SaslCode field, SaslCode value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal void SetField(int index, ref object field, object value)
+        {
+            this.fields |= (1 << index);
+            field = value;
+        }
+
+        internal uint GetField(int index, uint field, uint defaultValue = default(uint))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal ushort GetField(int index, ushort field, ushort defaultValue = default(ushort))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal bool GetField(int index, bool field, bool defaultValue = default(bool))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal byte GetField(int index, byte field, byte defaultValue = default(byte))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal ulong GetField(int index, ulong field, ulong defaultValue = default(ulong))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal string GetField(int index, string field, string defaultValue = default(string))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal byte[] GetField(int index, byte[] field, byte[] defaultValue = default(byte[]))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal Outcome GetField(int index, Outcome field, Outcome defaultValue = default(Outcome))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal Fields GetField(int index, Fields field, Fields defaultValue = default(Fields))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal Map GetField(int index, Map field, Map defaultValue = default(Map))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal ReceiverSettleMode GetField(int index, ReceiverSettleMode field, ReceiverSettleMode defaultValue = default(ReceiverSettleMode))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal SenderSettleMode GetField(int index, SenderSettleMode field, SenderSettleMode defaultValue = default(SenderSettleMode))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal DeliveryState GetField(int index, DeliveryState field, DeliveryState defaultValue = default(DeliveryState))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal Error GetField(int index, Error field, Error defaultValue = default(Error))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal DateTime GetField(int index, DateTime field, DateTime defaultValue = default(DateTime))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal Symbol GetField(int index, Symbol field, Symbol defaultValue = default(Symbol))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal SaslCode GetField(int index, SaslCode field, SaslCode defaultValue = default(SaslCode))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        internal object GetField(int index, object field, object defaultValue = default(object))
+        {
+            if ((this.fields & (1 << index)) == 0)
+            {
+                return defaultValue;
+            }
+
+            return field;
+        }
+
+        #endregion
+#else
         internal void SetField<T>(int index, ref T field, T value)
         {
             this.fields |= (1 << index);
@@ -79,7 +373,7 @@ namespace Amqp.Types
 
             return field;
         }
-
+#endif
 
         internal override void DecodeValue(ByteBuffer buffer)
         {

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -1658,7 +1658,7 @@ namespace Amqp.Types
         }
 
 #if NETMF_LITE
-        static Exception InvalidFormatCodeException(byte formatCode, int offset)
+        internal static Exception InvalidFormatCodeException(byte formatCode, int offset)
         {
             return new Exception("Format code " + formatCode + " at offset " + offset + " is invalid");
         }

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -421,6 +421,22 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Writes a nullable boolean value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The boolean value.</param>
+        /// <param name="smallEncoding">if true, try using small encoding if possible.</param>
+        public static void WriteBoolean(ByteBuffer buffer, bool? value, bool smallEncoding)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteBoolean(buffer, value.Value, smallEncoding);
+        }
+
+        /// <summary>
         /// Writes a boolean value to a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to write.</param>
@@ -440,6 +456,21 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Writes a nullable unsigned byte value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The unsigned byte value.</param>
+        public static void WriteUByte(ByteBuffer buffer, byte? value)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteUByte(buffer, value.Value);
+        }
+
+        /// <summary>
         /// Writes an unsigned byte value to a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to write.</param>
@@ -448,6 +479,21 @@ namespace Amqp.Types
         {
             AmqpBitConverter.WriteUByte(buffer, FormatCode.UByte);
             AmqpBitConverter.WriteUByte(buffer, value);
+        }
+
+        /// <summary>
+        /// Writes a nullable unsigned 16-bit integer value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The unsigned 16-bit integer value.</param>
+        public static void WriteUShort(ByteBuffer buffer, ushort? value)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteUShort(buffer, value.Value);
         }
 
         /// <summary>
@@ -483,6 +529,38 @@ namespace Amqp.Types
                 AmqpBitConverter.WriteUByte(buffer, FormatCode.SmallUInt);
                 AmqpBitConverter.WriteUByte(buffer, (byte)value);
             }
+        }
+
+        /// <summary>
+        /// Writes a nullable unsigned 32-bit integer value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The unsigned 32-bit integer value.</param>
+        /// <param name="smallEncoding">if true, try using small encoding if possible.</param>
+        public static void WriteUInt(ByteBuffer buffer, uint? value, bool smallEncoding)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteUInt(buffer, value.Value, smallEncoding);
+        }
+
+        /// <summary>
+        /// Writes a nullable unsigned 64-bit integer value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The unsigned 64-bit integer value.</param>
+        /// <param name="smallEncoding">if true, try using small encoding if possible.</param>
+        public static void WriteULong(ByteBuffer buffer, ulong? value, bool smallEncoding)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteULong(buffer, value.Value, smallEncoding);
         }
 
         /// <summary>
@@ -630,6 +708,21 @@ namespace Amqp.Types
                 AmqpBitConverter.WriteUByte(buffer, formatCode);
                 AmqpBitConverter.WriteBytes(buffer, value.Bytes, 0, value.Bytes.Length);
             }
+        }
+
+        /// <summary>
+        /// Writes a nullable timestamp value to a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="value">The timestamp value which is the milliseconds since UNIX epoch.</param>
+        public static void WriteTimestamp(ByteBuffer buffer, DateTime? value)
+        {
+            if (value == null)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+                return;
+            }
+            WriteTimestamp(buffer, value.Value);
         }
 
         /// <summary>
@@ -977,6 +1070,20 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and a boolean value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static bool? ReadBoolean(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadBoolean(buffer, formatCode);
+        }
+
+        /// <summary>
         /// Reads a boolean value from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1003,6 +1110,20 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and an unsigned byte value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static byte? ReadUByte(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadUByte(buffer, formatCode);
+        }
+
+        /// <summary>
         /// Reads an unsigned byte value from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1020,6 +1141,20 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and an unsigned 16-bit integer from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static ushort? ReadUShort(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadUShort(buffer, formatCode);
+        }
+
+        /// <summary>
         /// Reads an unsigned 16-bit integer from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1034,6 +1169,20 @@ namespace Amqp.Types
             {
                 throw InvalidFormatCodeException(formatCode, buffer.Offset);
             }
+        }
+
+        /// <summary>
+        /// Reads the format code and an unsigned 32-bit integer from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static uint? ReadUInt(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadUInt(buffer, formatCode);
         }
 
         /// <summary>
@@ -1062,6 +1211,20 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and an unsigned 64-bit integer from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static ulong? ReadULong(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadULong(buffer, formatCode);
+        }
+
+        /// <summary>
         /// Reads an unsigned 64-bit integer from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1084,6 +1247,20 @@ namespace Amqp.Types
             {
                 throw InvalidFormatCodeException(formatCode, buffer.Offset);
             }
+        }
+
+        /// <summary>
+        /// Reads the format code and a signed byte from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static sbyte? ReadByte(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadByte(buffer, formatCode);
         }
 
         /// <summary>
@@ -1249,6 +1426,20 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and a timestamp value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static DateTime? ReadTimestamp(ByteBuffer buffer)
+        {
+            byte formatCode = ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Null)
+            {
+                return null;
+            }
+            return ReadTimestamp(buffer, formatCode);
+        }
+
+        /// <summary>
         /// Reads a timestamp value from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1280,6 +1471,15 @@ namespace Amqp.Types
             {
                 throw InvalidFormatCodeException(formatCode, buffer.Offset);
             }
+        }
+
+        /// <summary>
+        /// Reads the format code and a binary value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static byte[] ReadBinary(ByteBuffer buffer)
+        {
+            return ReadBinary(buffer, ReadFormatCode(buffer));
         }
 
         /// <summary>
@@ -1317,6 +1517,15 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and a string value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static string ReadString(ByteBuffer buffer)
+        {
+            return ReadString(buffer, ReadFormatCode(buffer));
+        }
+
+        /// <summary>
         /// Reads a string value from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
@@ -1325,7 +1534,16 @@ namespace Amqp.Types
         {
             return ReadString(buffer, formatCode, FormatCode.String8Utf8, FormatCode.String32Utf8, "string");
         }
-                     
+
+        /// <summary>
+        /// Reads the format code and a symbol value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static Symbol ReadSymbol(ByteBuffer buffer)
+        {
+            return ReadSymbol(buffer, ReadFormatCode(buffer));
+        }
+
         /// <summary>
         /// Reads a symbol value from a buffer.
         /// </summary>
@@ -1425,11 +1643,34 @@ namespace Amqp.Types
         }
 
         /// <summary>
+        /// Reads the format code and a map value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static Map ReadMap(ByteBuffer buffer)
+        {
+            return ReadMap<Map>(buffer, ReadFormatCode(buffer));
+        }
+
+        /// <summary>
         /// Reads a map value from a buffer.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
         /// <param name="formatCode">The format code of the value.</param>
         public static Map ReadMap(ByteBuffer buffer, byte formatCode)
+        {
+            return ReadMap<Map>(buffer, formatCode);
+        }
+
+        /// <summary>
+        /// Reads the format code and Fields map value from a buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        public static Fields ReadFields(ByteBuffer buffer)
+        {
+            return ReadMap<Fields>(buffer, ReadFormatCode(buffer));
+        }
+
+        private static T ReadMap<T>(ByteBuffer buffer, byte formatCode) where T : Map, new()
         {
             if (formatCode == FormatCode.Null)
             {
@@ -1458,7 +1699,7 @@ namespace Amqp.Types
                 throw InvalidMapCountException(count);
             }
 
-            Map value = new Map();
+            T value = new T();
             for (int i = 0; i < count; i += 2)
             {
                 value.Add(ReadObject(buffer), ReadObject(buffer));
@@ -1531,7 +1772,7 @@ namespace Amqp.Types
             return new Exception(type.Name + " not supported");
         }
 #else
-        static AmqpException InvalidFormatCodeException(byte formatCode, int offset)
+        internal static AmqpException InvalidFormatCodeException(byte formatCode, int offset)
         {
             return new AmqpException(ErrorCode.DecodeError,
                 Fx.Format(SRAmqp.AmqpInvalidFormatCode, formatCode, offset));

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -19,7 +19,9 @@ namespace Amqp.Types
 {
     using System;
     using System.Collections;
+#if !NETMF
     using System.Collections.Generic;
+#endif
     using System.Text;
     using System.Globalization;
 
@@ -1475,7 +1477,9 @@ namespace Amqp.Types
 
             return value;
         }
-#else
+#endif
+
+#if NETMF
         /// <summary>
         /// Reads a map value from a buffer.
         /// </summary>
@@ -1518,7 +1522,9 @@ namespace Amqp.Types
 
             return value;
         }
+#endif
 
+#if NETMF && !NETMF_LITE
         /// <summary>
         /// Reads a Fields map value from a buffer.
         /// </summary>

--- a/src/Types/RestrictedDescribed.cs
+++ b/src/Types/RestrictedDescribed.cs
@@ -50,6 +50,27 @@ namespace Amqp.Types
         internal override void DecodeDescriptor(ByteBuffer buffer)
         {
             Encoder.ReadObject(buffer);
+            //var formatCode = Encoder.ReadFormatCode(buffer);
+            //if (formatCode == FormatCode.Described)
+            //{
+            //    formatCode = Encoder.ReadFormatCode(buffer);
+            //}
+
+            //if (formatCode == FormatCode.Symbol8 ||
+            //    formatCode == FormatCode.Symbol32)
+            //{
+            //    Encoder.ReadSymbol(buffer, formatCode);
+            //}
+            //else if (formatCode == FormatCode.ULong ||
+            //         formatCode == FormatCode.ULong0 ||
+            //         formatCode == FormatCode.SmallULong)
+            //{
+            //    Encoder.ReadULong(buffer, formatCode);
+            //}
+            //else
+            //{
+            //    throw Encoder.InvalidFormatCodeException(formatCode, buffer.Offset);
+            //}
         }
     }
 }

--- a/src/Types/RestrictedDescribed.cs
+++ b/src/Types/RestrictedDescribed.cs
@@ -49,28 +49,27 @@ namespace Amqp.Types
 
         internal override void DecodeDescriptor(ByteBuffer buffer)
         {
-            Encoder.ReadObject(buffer);
-            //var formatCode = Encoder.ReadFormatCode(buffer);
-            //if (formatCode == FormatCode.Described)
-            //{
-            //    formatCode = Encoder.ReadFormatCode(buffer);
-            //}
+            var formatCode = Encoder.ReadFormatCode(buffer);
+            if (formatCode == FormatCode.Described)
+            {
+                formatCode = Encoder.ReadFormatCode(buffer);
+            }
 
-            //if (formatCode == FormatCode.Symbol8 ||
-            //    formatCode == FormatCode.Symbol32)
-            //{
-            //    Encoder.ReadSymbol(buffer, formatCode);
-            //}
-            //else if (formatCode == FormatCode.ULong ||
-            //         formatCode == FormatCode.ULong0 ||
-            //         formatCode == FormatCode.SmallULong)
-            //{
-            //    Encoder.ReadULong(buffer, formatCode);
-            //}
-            //else
-            //{
-            //    throw Encoder.InvalidFormatCodeException(formatCode, buffer.Offset);
-            //}
+            if (formatCode == FormatCode.Symbol8 ||
+                formatCode == FormatCode.Symbol32)
+            {
+                Encoder.ReadSymbol(buffer, formatCode);
+            }
+            else if (formatCode == FormatCode.ULong ||
+                     formatCode == FormatCode.ULong0 ||
+                     formatCode == FormatCode.SmallULong)
+            {
+                Encoder.ReadULong(buffer, formatCode);
+            }
+            else
+            {
+                throw Encoder.InvalidFormatCodeException(formatCode, buffer.Offset);
+            }
         }
     }
 }

--- a/test/Common/ProtocolTests.cs
+++ b/test/Common/ProtocolTests.cs
@@ -67,7 +67,7 @@ namespace Test.Amqp
 
             this.testListener.RegisterTarget(TestPoint.Begin, (stream, channel, fields) =>
             {
-                TestListener.FRM(stream, 0x11UL, 0, channel, channel, 0u, 100u, 100u, 8u, null, null, null,
+                TestListener.FRM(stream, 0x11UL, 0, channel, channel, 0u, 100u, 100u, 8u, null, null,
                     new Fields() { { new Symbol("big-string"), new string('a', 1024) } });
                 return TestOutcome.Stop;
             });


### PR DESCRIPTION
Adresses #369 

Performance and allocations look much better now, see this benchmark that encodes and decodes a Header, the only allocations left are the actual Header instances:

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.16299.1268 (1709/FallCreatorsUpdate/Redstone3)
Intel Xeon CPU E5-1620 v2 3.70GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=3613278 Hz, Resolution=276.7570 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3416.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3416.0
```

|    Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
| EncodeOld | 537.83 ns | 8.927 ns | 7.454 ns | 0.0410 |     - |     - |     216 B |
| EncodeNew |  93.70 ns | 1.622 ns | 1.355 ns | 0.0137 |     - |     - |      72 B |
| DecodeOld | 252.36 ns | 3.412 ns | 3.025 ns | 0.0653 |     - |     - |     344 B |
| DecodeNew |  58.01 ns | 1.083 ns | 1.013 ns | 0.0137 |     - |     - |      72 B |


One behavioural change is introduced with the optimization. Previously null items at the end of the Fields list where not encoded. If I understood the AMQP spec correctly this is allowed but not strictly necessary. It could be accomplished with this method too, but would complicate the encoding a lot, so I didn't do it. I don't think the difference will be noticeable, but it will mean that a few more null bytes are sent over the wire now.

I also found 3 other places where allocations can be avoided (see other changesets).

BTW: What is the maximum C# version that can be used in this project? 