### PR TITLE
It should be possible to reset the creation-time and the absolute-expiry-time fields

### DIFF
--- a/src/Framing/Properties.cs
+++ b/src/Framing/Properties.cs
@@ -118,18 +118,18 @@ namespace Amqp.Framing
         /// <summary>
         /// Gets or sets the absolute-expiry-time field.
         /// </summary>
-        public DateTime AbsoluteExpiryTime
+        public DateTime? AbsoluteExpiryTime
         {
-            get { return this.Fields[8] == null ? DateTime.MinValue : (DateTime)this.Fields[8]; }
+            get { return (DateTime?)this.Fields[8]; }
             set { this.Fields[8] = value; }
         }
 
         /// <summary>
         /// Gets or sets the creation-time field.
         /// </summary>
-        public DateTime CreationTime
+        public DateTime? CreationTime
         {
-            get { return this.Fields[9] == null ? DateTime.MinValue : (DateTime)this.Fields[9]; }
+            get { return (DateTime?)this.Fields[9]; }
             set { this.Fields[9] = value; }
         }
 

--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -637,10 +637,17 @@ namespace Amqp.Types
         /// </summary>
         /// <param name="buffer">The buffer to write.</param>
         /// <param name="value">The timestamp value which is the milliseconds since UNIX epoch.</param>
-        public static void WriteTimestamp(ByteBuffer buffer, DateTime value)
+        public static void WriteTimestamp(ByteBuffer buffer, DateTime? value)
         {
-            AmqpBitConverter.WriteUByte(buffer, FormatCode.TimeStamp);
-            AmqpBitConverter.WriteLong(buffer, DateTimeToTimestamp(value));
+            if (value.HasValue)
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.TimeStamp);
+                AmqpBitConverter.WriteLong(buffer, DateTimeToTimestamp(value.Value));
+            }
+            else
+            {
+                AmqpBitConverter.WriteUByte(buffer, FormatCode.Null);
+            }
         }
 
         /// <summary>
@@ -1253,11 +1260,15 @@ namespace Amqp.Types
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
         /// <param name="formatCode">The format code of the value.</param>
-        public static DateTime ReadTimestamp(ByteBuffer buffer, byte formatCode)
+        public static DateTime? ReadTimestamp(ByteBuffer buffer, byte formatCode)
         {
             if (formatCode == FormatCode.TimeStamp)
             {
                 return TimestampToDateTime(AmqpBitConverter.ReadLong(buffer));
+            }
+            else if (formatCode == FormatCode.Null)
+            {
+                return null;
             }
             else
             {


### PR DESCRIPTION
As *creation-time* and *absolute-expiry-time fields* are represented as DateTime structs there is no way to reset their values once set. This PR addresses this issue by changing their types to nullable DateTime. The same way as it is implemented in azure-amqp https://github.com/Azure/azure-amqp/blob/4dcaf85d6073902c62b6866112447020321095da/src/Framing/Properties.cs#L67-L75

It affects the implementation of nms-amqp https://github.com/apache/activemq-nms-amqp/pull/8#issuecomment-517449165