### PR TITLE
Unify create connection method

### DIFF
--- a/src/Net/ConnectionFactory.cs
+++ b/src/Net/ConnectionFactory.cs
@@ -105,20 +105,16 @@ namespace Amqp
         {
             return this.CreateAsync(address, null, null, handler);
         }
-
+        
         /// <summary>
         /// Creates a new connection with a custom open frame and a callback to handle remote open frame.
         /// </summary>
         /// <param name="address">The address of remote endpoint to connect to.</param>
         /// <param name="open">If specified, it is sent to open the connection, otherwise an open frame created from the AMQP settings property is sent.</param>
         /// <param name="onOpened">If specified, it is invoked when an open frame is received from the remote peer.</param>
+        /// /// <param name="handler">The protocol handler.</param>
         /// <returns>A task for the connection creation operation. On success, the result is an AMQP <see cref="Connection"/></returns>
-        public Task<Connection> CreateAsync(Address address, Open open = null, OnOpened onOpened = null)
-        {
-            return this.CreateAsync(address, open, onOpened, null);
-        }
-
-        async Task<Connection> CreateAsync(Address address, Open open, OnOpened onOpened, IHandler handler)
+        public async Task<Connection> CreateAsync(Address address, Open open = null, OnOpened onOpened = null, IHandler handler = null)
         {
             IAsyncTransport transport;
             TransportProvider provider;


### PR DESCRIPTION
This PR unifies two create connection overloads into one that accepts all the parameters. I understand why it wasn't done that way in the first place (you can utilize Handler API to set Open frame and subscribe to OnOpened callback), but after playing with this api for a while I find it not particularly user friendly. 

I believe this is not a breaking change, so we could roll it out in a form of a minor update?