### PR TITLE
Send async and receive async may cause deadlocks

### DIFF
--- a/src/Net/TaskExtensions.cs
+++ b/src/Net/TaskExtensions.cs
@@ -280,7 +280,7 @@ namespace Amqp
         readonly static TimerCallback onTimer = OnTimer;
         readonly Timer timer;
 
-        public SendTask(SenderLink link, Message message, DeliveryState state, TimeSpan timeout)
+        public SendTask(SenderLink link, Message message, DeliveryState state, TimeSpan timeout) : base(TaskCreationOptions.RunContinuationsAsynchronously)
         {
             this.timer = new Timer(onTimer, this, (int)timeout.TotalMilliseconds, -1);
             link.Send(message, state, onOutcome, this);

--- a/src/Net/TaskExtensions.cs
+++ b/src/Net/TaskExtensions.cs
@@ -250,7 +250,7 @@ namespace Amqp
             }
 #endif
 
-            TaskCompletionSource<Message> tcs = new TaskCompletionSource<Message>();
+            TaskCompletionSource<Message> tcs = new TaskCompletionSource<Message>(TaskCreationOptions.RunContinuationsAsynchronously);
             var message = this.ReceiveInternal(
                 (l, m) =>
                 {


### PR DESCRIPTION
During the work on https://github.com/Havret/ActiveMQ.Net I've come across a nasty deadlock in the AmqpNetLite. It's a rather well know problem with the usage of  TaskCompletionSource and async/await. You can find a great article about it [here](https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/).

tldr: TaskCompletionSource created with default constructor may cause deadlocks and other threading issues by running all “async” continuations in the thread that sets the result of a task.

I've created 2 simple tests that may be used to reproduce the issue. 

Usages of TaskCompletionSource are quite common throughout the solution. These two are not the only places where you can find them. I haven't done it yet, but I think all other places where TaskCompletionSource is used should be updated as well. I could do it in this PR. @xinchen10 what do you think? 

**EDIT**: Apparently some builds are failing because Micro Framework doesn't support RunContinuationsAsynchronously. 