### PR TITLE
Enable nanoFramework build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       FRAMEWORKS_TO_BUILD: REST_OF_FRAMEWORKS
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      FRAMEWORKS_TO_BUILD: NANOFRAMEWORK
 
 before_build:
 - ps: >-


### PR DESCRIPTION
- The build issues where being caused by a new version of the metadata processor. The new version is fully functional now.

- Closes #396 