### PR TITLE
Fix issue with ReconnectSender example sending empty Begin

### DIFF
--- a/Examples/Reconnect/ReconnectSender/ReconnectSender.cs
+++ b/Examples/Reconnect/ReconnectSender/ReconnectSender.cs
@@ -142,7 +142,14 @@ namespace ReconnectSender
 
             connection = (Connection)conn;
 
-            session = new Session(connection, new Begin() { }, onBegin);
+            var begin = new Begin()
+            {
+                IncomingWindow = 2048,
+                OutgoingWindow = 2048,
+                NextOutgoingId = 0
+            };
+
+            session = new Session(connection, begin, onBegin);
         }
 
         /// <summary>


### PR DESCRIPTION
The reconnect example sends an unpopulated Begin performative to the
remote which violates the AMQP specification wherein the fields carrying
the next-outgoingid, incomingWindow and outgoingWindow are mandatory.
This results in failed connection attempts on remotes where these values
are validated and the begin attempt is rejected.

The example is modified here with a workaround that populates these
values with defaults similar to those in the Session class itself. In the
future it might be sensible to add another constructor that doesn't need
the Begin as the internal Default mechanism can construct one with the
Connection provided.  The onBegin callback is really the main thing that
is of use in this context.