### PR TITLE
Rework FX output

### DIFF
--- a/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -27,25 +27,24 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
+++ b/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -27,30 +27,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.26\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.29\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/Device/Device.Thermometer.nanoFramework/packages.config
+++ b/Examples/Device/Device.Thermometer.nanoFramework/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.26" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/ServiceBus.EventHub.nanoFramework.nfproj
+++ b/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/ServiceBus.EventHub.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -29,25 +29,24 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/packages.config
+++ b/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/amqp-nanoFramework.sln
+++ b/amqp-nanoFramework.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2047
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31105.61
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Amqp.nanoFramework", "nanoFramework\Amqp.nanoFramework\Amqp.nanoFramework.nfproj", "{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}"
 EndProject
@@ -25,26 +24,31 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD8A8669-2183-4D5C-87B7-1CAB4CD26E90}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F66A975C-A958-4D17-BCF3-AC28CE9D460B}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AA510BD3-3AA7-4D0C-8B2E-FD03FEE288F4}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{058153C5-5319-43B3-A10B-C50521ED02EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{058153C5-5319-43B3-A10B-C50521ED02EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{058153C5-5319-43B3-A10B-C50521ED02EA}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{058153C5-5319-43B3-A10B-C50521ED02EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{058153C5-5319-43B3-A10B-C50521ED02EA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{058153C5-5319-43B3-A10B-C50521ED02EA}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3E5028BE-B7FA-4D5D-A931-132032FD1171}.Release|Any CPU.Deploy.0 = Release|Any CPU

--- a/amqp-nanoFramework.sln
+++ b/amqp-nanoFramework.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27703.2047

--- a/amqp-netmf.sln
+++ b/amqp-netmf.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1

--- a/amqp.sln
+++ b/amqp.sln
@@ -132,15 +132,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetMF44", "netmf\Amqp.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Amqp.NetMF", "netmf\Test.Amqp.NetMF.csproj", "{2C4CBC7A-16BD-4F27-86BA-3CF38BE0F426}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", "csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", .csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", "csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", .csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", "csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", .csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", "csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", .csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", "csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", .csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/amqp.sln
+++ b/amqp.sln
@@ -132,15 +132,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetMF44", "netmf\Amqp.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Amqp.NetMF", "netmf\Test.Amqp.NetMF.csproj", "{2C4CBC7A-16BD-4F27-86BA-3CF38BE0F426}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", .csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", "csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", .csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", "csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", .csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", "csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", .csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", "csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", .csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", "csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/nanoFramework/Amqp.Micro.nanoFramework/Amqp.Micro.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.Micro.nanoFramework/Amqp.Micro.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -103,33 +103,32 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.25\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.30\lib\nanoFramework.Runtime.Native.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.24\lib\System.Math.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.29\lib\System.Math.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nanoFramework/Amqp.Micro.nanoFramework/packages.config
+++ b/nanoFramework/Amqp.Micro.nanoFramework/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.25" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.3.1-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/nanoFramework/Amqp.nanoFramework/Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.nanoFramework/Amqp.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -302,37 +302,36 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.22\lib\nanoFramework.ResourceManager.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.27\lib\nanoFramework.ResourceManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.25\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.30\lib\nanoFramework.Runtime.Native.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.24\lib\System.Math.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.29\lib\System.Math.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nanoFramework/Amqp.nanoFramework/packages.config
+++ b/nanoFramework/Amqp.nanoFramework/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.22" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.25" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.27" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.3.1-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/nanoFramework/Test.Amqp.nanoFramework/Test.Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Test.Amqp.nanoFramework/Test.Amqp.nanoFramework.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -35,37 +35,36 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.10.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.9\lib\mscorlib.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.1-preview.11\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.22\lib\nanoFramework.ResourceManager.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.27\lib\nanoFramework.ResourceManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.9\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.14\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.25\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.30\lib\nanoFramework.Runtime.Native.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.24\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.29\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.24\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.29\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.24\lib\System.Math.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.29\lib\System.Math.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.6.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.29\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.3-preview.33\lib\System.Net.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nanoFramework/Test.Amqp.nanoFramework/packages.config
+++ b/nanoFramework/Test.Amqp.nanoFramework/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.22" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.25" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.24" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.3-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.24" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.27" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.3.1-preview.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.3-preview.33" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.29" targetFramework="netnanoframework10" />
 </packages>

--- a/netmf/NetMFLite/Fx.cs
+++ b/netmf/NetMFLite/Fx.cs
@@ -72,6 +72,33 @@ namespace Amqp
                         {
                             sb.Append('[');
                             bool first = true;
+
+#if (NANOFRAMEWORK_1_0)
+                            if(it is string)
+                            {
+                                if (!first)
+                                {
+                                    sb.Append(',');
+                                }
+
+                                sb.Append(it);
+                                first = false;
+                            }
+                            else
+                            {
+                                foreach (var o in it)
+                                {
+                                    if (!first)
+                                    {
+                                        sb.Append(',');
+                                    }
+
+                                    sb.Append(o);
+                                    first = false;
+                                }
+                            }
+
+#else
                             foreach (var o in it)
                             {
                                 if (!first)
@@ -82,6 +109,7 @@ namespace Amqp
                                 sb.Append(o);
                                 first = false;
                             }
+#endif
 
                             sb.Append(']');
                         }

--- a/nuspec/AMQPNetLite.Core.nuspec
+++ b/nuspec/AMQPNetLite.Core.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetLite.Core</id>
     <title>AMQP.Net Lite on .Net Core</title>

--- a/nuspec/AMQPNetLite.NetMF.nuspec
+++ b/nuspec/AMQPNetLite.NetMF.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetLite.NetMF</id>
     <title>AMQP.Net Lite for NetMF</title>

--- a/nuspec/AMQPNetLite.Serialization.nuspec
+++ b/nuspec/AMQPNetLite.Serialization.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetLite.Serialization</id>
     <title>AMQP.Net Lite AMQP Serializer on .Net Core</title>

--- a/nuspec/AMQPNetLite.WebSockets.nuspec
+++ b/nuspec/AMQPNetLite.WebSockets.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetLite.WebSockets</id>
     <title>AMQP.Net Lite WebSockets Client on .Net Core</title>

--- a/nuspec/AMQPNetLite.nanoFramework.nuspec
+++ b/nuspec/AMQPNetLite.nanoFramework.nuspec
@@ -18,14 +18,14 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP net netmf nf nanoframework</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" />
-      <dependency id="nanoFramework.ResourceManager" version="1.1.2-preview.22" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.25" />
-      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.24" />
-      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.24" />
-      <dependency id="nanoFramework.System.Net" version="1.6.3-preview.29" />
-      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.24" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" />
+      <dependency id="nanoFramework.ResourceManager" version="1.1.2-preview.27" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" />
+      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.29" />
+      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.29" />
+      <dependency id="nanoFramework.System.Net" version="1.6.3-preview.33" />
+      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.29" />
     </dependencies>
   </metadata>
   <files>

--- a/nuspec/AMQPNetLite.nuspec
+++ b/nuspec/AMQPNetLite.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetLite</id>
     <title>AMQP.Net Lite</title>
@@ -38,7 +38,6 @@
   <files>
     <file src="dotnet\" target="lib\netstandard2.0" />
     <file src="dotnet\" target="lib\netstandard1.3" />
-    
     <file src="bin\Release\Amqp.Net\Amqp.Net.dll" target="lib\net45" />
     <file src="bin\Release\Amqp.Net\Amqp.Net.pdb" target="lib\net45" />
     <file src="bin\Release\Amqp.Net\Amqp.Net.XML" target="lib\net45" />
@@ -49,12 +48,10 @@
     <file src="bin\Release\Amqp.Net35\Amqp.Net.dll" target="lib\net35" />
     <file src="bin\Release\Amqp.Net35\Amqp.Net.pdb" target="lib\net35" />
     <file src="bin\Release\Amqp.Net35\Amqp.Net.xml" target="lib\net35" />
-
     <file src="bin\Release\Amqp.NetCore\Amqp.Net.dll" target="lib\netcore451" />
     <file src="bin\Release\Amqp.NetCore\Amqp.Net.pdb" target="lib\netcore451" />
     <file src="bin\Release\Amqp.NetCore\Amqp.Net.pri" target="lib\netcore451" />
     <file src="bin\Release\Amqp.NetCore\Amqp.Net.xml" target="lib\netcore451" />
-
     <file src="bin\Release\Amqp.Uwp\Amqp.Net.dll" target="lib\uap10.0" />
     <file src="bin\Release\Amqp.Uwp\Amqp.Net.pdb" target="lib\uap10.0" />
     <file src="bin\Release\Amqp.Uwp\Amqp.Net.pri" target="lib\uap10.0" />

--- a/nuspec/AMQPNetMicro.nanoFramework.nuspec
+++ b/nuspec/AMQPNetMicro.nanoFramework.nuspec
@@ -14,13 +14,13 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP netmf nf nanoframework</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.1-preview.9" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.9" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.25" />
-      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.24" />
-      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.24" />
-      <dependency id="nanoFramework.System.Net" version="1.6.3-preview.29" />
-      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.24" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.1-preview.11" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.14" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.30" />
+      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.29" />
+      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.29" />
+      <dependency id="nanoFramework.System.Net" version="1.6.3-preview.33" />
+      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.29" />
     </dependencies>
   </metadata>
   <files>

--- a/nuspec/AMQPNetMicro.nuspec
+++ b/nuspec/AMQPNetMicro.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>AMQPNetMicro</id>
     <title>A compact version of AMQP.Net Lite for NETMF</title>


### PR DESCRIPTION
- Rework DebugPrint in FX output.
  (.NET nanoFramework doesn't implement String.Enumerator and the CLR now throws a not supported exception when called)
- Update several .NET nanoFramework NuGets.