### PR TITLE
Expose option to cancel inflight message

### DIFF
--- a/src/Net/TaskExtensions.cs
+++ b/src/Net/TaskExtensions.cs
@@ -212,7 +212,7 @@ namespace Amqp
             }
             catch (TimeoutException)
             {
-                this.OnTimeout(message);
+                this.Cancel(message);
                 throw;
             }
         }

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -110,7 +110,7 @@ namespace Amqp
             bool signaled = acked.WaitOne(waitMilliseconds);
             if (!signaled)
             {
-                this.OnTimeout(message);
+                this.Cancel(message);
                 throw new TimeoutException(Fx.Format(SRAmqp.AmqpTimeout, "send", waitMilliseconds, "message"));
             }
 
@@ -215,7 +215,12 @@ namespace Amqp
             this.WriteDelivery(delivery);
         }
 
-        void OnTimeout(Message message)
+        /// <summary>
+        /// Removes the message from the internal outgoing list if it hasn't been sent yet.
+        /// Issues released disposition frame for inflight message.
+        /// </summary>
+        /// <param name="message">The message to cancel.</param>
+        public void Cancel(Message message)
         {
             lock (this.ThisLock)
             {


### PR DESCRIPTION
This exposes the option to cancel inflight messages. Currently, if you use Send overload that accepts OutcomeCallback as an argument, there is no option to cancel inflight messages. This may be really useful when you have custom timeout logic, for instance, build around CancellationToken as we have in  **.NET Client for ActiveMQ Artemis** https://github.com/Havret/dotnet-activemq-artemis-client/blob/master/src/ActiveMQ.Artemis.Client/ProducerBase.cs#L36-L47.

I'm not entirely sure that **Cancel** is the best name, but original `OnTimeout` doesn't seem right for public API. If you have any suggestions I can rename it.

@xinchen10 Any chance that we could have this released in short order. This is a huge blocker for our implementation of  NMS AMQP, as we cannot use producer flow control properly without this. 