### PR TITLE
Update .NET nanoFramework dependencies

### DIFF
--- a/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/Device.SmallMemory.nanoFramework.nfproj
@@ -26,25 +26,35 @@
     <ProjectReference Include="..\..\..\nanoFramework\Amqp.Micro.nanoFramework\Amqp.Micro.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
+++ b/Examples/Device/Device.SmallMemory.nanoFramework/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
+++ b/Examples/Device/Device.Thermometer.nanoFramework/Device.Thermometer.nanoFramework.nfproj
@@ -26,29 +26,40 @@
     <ProjectReference Include="..\..\..\nanoFramework\Amqp.nanoFramework\Amqp.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.31\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.47\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/Device/Device.Thermometer.nanoFramework/packages.config
+++ b/Examples/Device/Device.Thermometer.nanoFramework/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.47" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/ServiceBus.EventHub.nanoFramework.nfproj
+++ b/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/ServiceBus.EventHub.nanoFramework.nfproj
@@ -28,25 +28,35 @@
     <ProjectReference Include="..\..\..\nanoFramework\Amqp.nanoFramework\Amqp.nanoFramework.nfproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/packages.config
+++ b/Examples/ServiceBus/ServiceBus.EventHub.nanoFramework/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/amqp.sln
+++ b/amqp.sln
@@ -132,15 +132,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetMF44", "netmf\Amqp.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Amqp.NetMF", "netmf\Test.Amqp.NetMF.csproj", "{2C4CBC7A-16BD-4F27-86BA-3CF38BE0F426}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", "csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", .csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", "csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", .csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", "csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", .csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", "csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", .csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", "csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", .csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/amqp.sln
+++ b/amqp.sln
@@ -132,15 +132,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetMF44", "netmf\Amqp.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Amqp.NetMF", "netmf\Test.Amqp.NetMF.csproj", "{2C4CBC7A-16BD-4F27-86BA-3CF38BE0F426}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", .csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net", "csproj\Amqp.Net.csproj", "{92153715-1D99-43B1-B291-470CF91A156D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", .csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net35", "csproj\Amqp.Net35.csproj", "{4FB9C0D9-C3A8-4FB5-86CD-927E5EBC6885}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", .csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Net40", "csproj\Amqp.Net40.csproj", "{4A250B81-35E9-4D2F-8030-62909F6C8C63}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", .csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.NetCore", "csproj\Amqp.NetCore.csproj", "{35F64888-3446-444D-8E44-128378434AB3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", .csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.Uwp", "csproj\Amqp.Uwp.csproj", "{75DC3484-F6C8-4373-A8C4-9D1A8C9FC3B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ before_build:
 
       # copy build files to msbuild location
       Write-Debug "Copy build files to msbuild location"
-      $msbuildPath = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild"
+      $msbuildPath = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild"
       Copy-Item -Path "$($env:USERPROFILE)\nf-extension\`$MSBuild\nanoFramework" -Destination $msbuildPath -Recurse
 
       'OK' | Write-Host -ForegroundColor Green

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       FRAMEWORKS_TO_BUILD: REST_OF_FRAMEWORKS
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       FRAMEWORKS_TO_BUILD: NANOFRAMEWORK
 
 before_build:
@@ -73,9 +73,9 @@ before_build:
       $webClient.DownloadFile("http://vsixgallery.com/feed/author/nanoframework", $vsixFeedXml)
       [xml]$feedDetails = Get-Content $vsixFeedXml
 
-      # assuming this is building on VS2017 only
-      $extensionUrl = $feedDetails.feed.entry[0].content.src
-      $vsixPath = Join-Path  $($env:USERPROFILE) "nanoFramework.Tools.VS2017.Extension.zip"
+      # assuming this is building on VS2019 only
+      $extensionUrl = $feedDetails.feed.entry[1].content.src
+      $vsixPath = Join-Path  $($env:USERPROFILE) "nanoFramework.Tools.VS2019.Extension.zip"
 
       # download VS extension
       Write-Debug "Download VSIX file from $extensionUrl to $vsixPath"

--- a/nanoFramework/Amqp.Micro.nanoFramework/Amqp.Micro.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.Micro.nanoFramework/Amqp.Micro.nanoFramework.nfproj
@@ -102,33 +102,35 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.32\lib\nanoFramework.Runtime.Native.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.31\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nanoFramework/Amqp.Micro.nanoFramework/packages.config
+++ b/nanoFramework/Amqp.Micro.nanoFramework/packages.config
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/nanoFramework/Amqp.nanoFramework/Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Amqp.nanoFramework/Amqp.nanoFramework.nfproj
@@ -292,48 +292,51 @@
     <Folder Include="Handler\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.29\lib\nanoFramework.ResourceManager.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.32\lib\nanoFramework.Runtime.Native.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.31\lib\System.Math.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="nF\nanoSRAmqp.resx">
       <Generator>nFResXFileCodeGenerator</Generator>
       <LastGenOutput>nanoSRAmqp.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Amqp</CustomToolNamespace>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.41\lib\nanoFramework.ResourceManager.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/nanoFramework/Amqp.nanoFramework/packages.config
+++ b/nanoFramework/Amqp.nanoFramework/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.41" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/nanoFramework/Test.Amqp.nanoFramework/Test.Amqp.nanoFramework.nfproj
+++ b/nanoFramework/Test.Amqp.nanoFramework/Test.Amqp.nanoFramework.nfproj
@@ -34,37 +34,40 @@
     <Folder Include="Test\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.3-preview.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.10.5-preview.13\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.1.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.29\lib\nanoFramework.ResourceManager.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.ResourceManager.1.1.2-preview.41\lib\nanoFramework.ResourceManager.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.0-preview.16\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.9.1-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.5.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.1-preview.32\lib\nanoFramework.Runtime.Native.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.31\lib\nanoFramework.System.Collections.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.2.0-preview.67\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.35\lib\nanoFramework.System.Text.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.1.1-preview.61\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.3.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Math.1.3.1-preview.31\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Math.1.4.1-preview.5\lib\System.Math.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Net, Version=1.6.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.2\lib\System.Net.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.6.5-preview.35\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nanoFramework/Test.Amqp.nanoFramework/packages.config
+++ b/nanoFramework/Test.Amqp.nanoFramework/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.29" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.1-preview.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.2.0-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.3.1-preview.31" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.6.5-preview.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Text" version="1.1.1-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.ResourceManager" version="1.1.2-preview.41" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.2.0-preview.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.5-preview.35" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Text" version="1.1.1-preview.61" targetFramework="netnanoframework10" />
 </packages>

--- a/nuspec/AMQPNetLite.nanoFramework.nuspec
+++ b/nuspec/AMQPNetLite.nanoFramework.nuspec
@@ -18,14 +18,13 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP net netmf nf nanoframework</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" />
-      <dependency id="nanoFramework.ResourceManager" version="1.1.2-preview.29" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.32" />
-      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.31" />
-      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.31" />
-      <dependency id="nanoFramework.System.Net" version="1.6.5-preview.2" />
-      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.35" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" />
+      <dependency id="nanoFramework.ResourceManager" version="1.1.2-preview.41" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" />
+      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.67" />
+      <dependency id="nanoFramework.System.Math" version="1.4.1-preview.5" />
+      <dependency id="nanoFramework.System.Net" version="1.6.5-preview.35" />
+      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.61" />
     </dependencies>
   </metadata>
   <files>

--- a/nuspec/AMQPNetMicro.nanoFramework.nuspec
+++ b/nuspec/AMQPNetMicro.nanoFramework.nuspec
@@ -14,13 +14,12 @@
     <copyright>Copyright 2014</copyright>
     <tags>AMQP netmf nf nanoframework</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.3-preview.7" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.16" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.5.1-preview.32" />
-      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.31" />
-      <dependency id="nanoFramework.System.Math" version="1.3.1-preview.31" />
-      <dependency id="nanoFramework.System.Net" version="1.6.5-preview.2" />
-      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.35" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.5-preview.13" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.1-preview.5" />
+      <dependency id="nanoFramework.System.Collections" version="1.2.0-preview.67" />
+      <dependency id="nanoFramework.System.Math" version="1.4.1-preview.5" />
+      <dependency id="nanoFramework.System.Net" version="1.6.5-preview.35" />
+      <dependency id="nanoFramework.System.Text" version="1.1.1-preview.61" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
- Also changing VS image to 2019 to build nanoFramework. (addresses build issues reported in #466)