### PR TITLE
Expose Message.GetEstimatedMessageSize()

### DIFF
--- a/src/Message.cs
+++ b/src/Message.cs
@@ -288,7 +288,7 @@ namespace Amqp
             return 64;
         }
 
-        int GetEstimatedMessageSize()
+        public int GetEstimatedMessageSize()
         {
             int size = 0;
             if (this.Header != null) size += 64;

--- a/src/Message.cs
+++ b/src/Message.cs
@@ -288,6 +288,9 @@ namespace Amqp
             return 64;
         }
 
+        /// <summary>
+        /// Gets estimated message size in bytes.
+        /// </summary>
         public int GetEstimatedMessageSize()
         {
             int size = 0;


### PR DESCRIPTION
I would kindly like to suggest to expose GetEstimatedMessageSize() as public in Message class. 
It would be useful for example to implement logic for checking maximum message size that is being send.