### PR TITLE
Update Address.cs

### DIFF
--- a/src/Address.cs
+++ b/src/Address.cs
@@ -202,7 +202,7 @@ namespace Amqp
                             state = ParseState.Path;
                             startIndex = i;
                         }
-                        else if (state == ParseState.Password)
+                        else if (state == ParseState.Password && this.Password != null)
                         {
                             this.Host = this.User;
                             this.User = null;


### PR DESCRIPTION
Fix for password that contains slashes in it, for example: "8fFXBRKSsrBzCXj3xf1cXgY+x/Ybpr4mOxe7twaoH8g=". It's very common that Azure generate this kind of password.