### PR TITLE
Close underlying socket on dispose

### DIFF
--- a/src/Net/TcpTransport.cs
+++ b/src/Net/TcpTransport.cs
@@ -128,7 +128,7 @@ namespace Amqp
                     localCertificateSelectionCallback = ssl.LocalCertificateSelectionCallback;
                 }
 
-                SslStream sslStream = new SslStream(new NetworkStream(socket), false, remoteCertificateValidationCallback, localCertificateSelectionCallback);
+                SslStream sslStream = new SslStream(new NetworkStream(socket, true), false, remoteCertificateValidationCallback, localCertificateSelectionCallback);
                 if (handler != null && handler.CanHandle(EventId.SslAuthenticate))
                 {
                     handler.Handle(Event.Create(EventId.SslAuthenticate, connection, null, null, sslStream));


### PR DESCRIPTION
Set the `NetworkStream` as owner of the underlying `Socket`, so that disposing the `NetworkStream` also disposes the `Socket`.

Fixes #525 