### PR TITLE
AmqpSettings.IdleTimeout int to uint

### DIFF
--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -240,7 +240,7 @@ namespace Amqp
                     HostName = amqpSettings.HostName ?? this.address.Host,
                     ChannelMax = this.channelMax,
                     MaxFrameSize = this.maxFrameSize,
-                    IdleTimeOut = (uint)amqpSettings.IdleTimeout / 2
+                    IdleTimeOut = amqpSettings.IdleTimeout / 2
                 };
             }
 

--- a/src/Net/AmqpSettings.cs
+++ b/src/Net/AmqpSettings.cs
@@ -71,7 +71,7 @@ namespace Amqp
         /// Gets or sets the connection idle timeout. Half the value is set
         /// as the value of open.idle-time-out field.
         /// </summary>
-        public int IdleTimeout
+        public uint IdleTimeout
         {
             get;
             set;

--- a/src/Net/ConnectionFactoryBase.cs
+++ b/src/Net/ConnectionFactoryBase.cs
@@ -42,7 +42,7 @@ namespace Amqp
             {
                 MaxFrameSize = (int)Connection.DefaultMaxFrameSize,
                 ContainerId = Connection.MakeAmqpContainerId(),
-                IdleTimeout = int.MaxValue,
+                IdleTimeout = uint.MaxValue,
                 MaxSessionsPerConnection = Connection.DefaultMaxSessions,
                 MaxLinksPerSession = Connection.DefaultMaxLinksPerSession
             };


### PR DESCRIPTION
Change the default AmqpSettings.IdleTimeout from int to uint.
Chenge the initialization from int.MaxValue to uint.MaxValue