### PR TITLE
Test broker: support custom node to handle protocol events

### DIFF
--- a/test/Common/ProtocolTests.cs
+++ b/test/Common/ProtocolTests.cs
@@ -917,6 +917,7 @@ namespace Test.Amqp
         public void SmallSessionWindowWithLinkCloseTest()
         {
             ManualResetEvent done = new ManualResetEvent(false);
+            ManualResetEvent sendDone = new ManualResetEvent(false);
 
             int window = 43;
             int total = 8000;
@@ -947,6 +948,7 @@ namespace Test.Amqp
                 }
                 if (received >= 3000 && received % 1000 == 0)
                 {
+                    sendDone.WaitOne();
                     TestListener.FRM(stream, 0x16UL, 0, channel, (uint)((received / 1000) - 3), true);
                 }
                 return TestOutcome.Stop;
@@ -972,6 +974,8 @@ namespace Test.Amqp
                     },
                     null);
             }
+
+            sendDone.Set();
 
             Assert.IsTrue(done.WaitOne(10000), $"total:{total} received:{received} success:{success} fail:{cancel}");
 

--- a/test/Common/TestAmqpBroker.cs
+++ b/test/Common/TestAmqpBroker.cs
@@ -29,7 +29,7 @@ namespace Listener.IContainer
     using global::Amqp.Types;
     using Test.Common;
 
-    public interface INode
+    public interface INode : IHandler
     {
         string Name { get; }
 
@@ -147,11 +147,19 @@ namespace Listener.IContainer
 
         bool IHandler.CanHandle(EventId id)
         {
-            return id == EventId.ConnectionRemoteOpen;
+            return true;
         }
 
         void IHandler.Handle(Event protocolEvent)
         {
+            foreach (var node in this.nodes)
+            {
+                if (node.CanHandle(protocolEvent.Id))
+                {
+                    node.Handle(protocolEvent);
+                }
+            }
+
             switch (protocolEvent.Id)
             {
                 case EventId.ConnectionRemoteOpen:


### PR DESCRIPTION
This PR adds support for custom node implementation to handle protocol events in the test broker.