### PR TITLE
Add OnLinkStateProperties callback for flow link-state properties

### DIFF
--- a/src/IAmqpObject.cs
+++ b/src/IAmqpObject.cs
@@ -1,4 +1,4 @@
-﻿//  ------------------------------------------------------------------------------------
+//  ------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation
 //  All rights reserved. 
 //  
@@ -64,6 +64,17 @@ namespace Amqp
     /// <param name="receiver">The receiver link from which a message is received.</param>
     /// <param name="message">The received message.</param>
     public delegate void MessageCallback(IReceiverLink receiver, Message message);
+
+    /// <summary>
+    /// Invoked when the remote peer sends a flow performative that includes link-state properties
+    /// (the <c>properties</c> field).
+    /// </summary>
+    /// <param name="link">The link that received the flow.</param>
+    /// <param name="properties">The link-state properties map from the flow frame.</param>
+    /// <remarks>
+    /// The callback runs on the connection I/O thread. Lengthy work can reduce throughput; keep the handler minimal.
+    /// </remarks>
+    public delegate void OnLinkStateProperties(ILink link, Fields properties);
 
     /// <summary>
     /// Represents an AMQP object.
@@ -182,6 +193,11 @@ namespace Amqp
         /// or the link was closed instead of being detached.
         /// </remarks>
         void Detach(Error error);
+
+        /// <summary>
+        /// Optional callback when the peer includes link-state properties on a flow performative.
+        /// </summary>
+        OnLinkStateProperties OnLinkStateProperties { get; set; }
     }
 
     /// <summary>

--- a/src/Link.cs
+++ b/src/Link.cs
@@ -20,6 +20,7 @@ namespace Amqp
     using System;
     using Amqp.Framing;
     using Amqp.Handler;
+    using Amqp.Types;
 
     /// <summary>
     /// The state of a link.
@@ -223,7 +224,16 @@ namespace Amqp
         {
             get { return this.session; }
         }
-        
+
+        /// <summary>
+        /// Optional callback when the remote peer sends link-state properties in a flow performative.
+        /// </summary>
+        /// <remarks>
+        /// Invoked on the connection I/O thread when the flow's properties field is present and non-empty.
+        /// Avoid blocking or heavy work in the handler.
+        /// </remarks>
+        public OnLinkStateProperties OnLinkStateProperties { get; set; }
+
         /// <summary>
         /// Gets the link state.
         /// </summary>
@@ -391,6 +401,23 @@ namespace Amqp
 
                 this.SendDetach(error);
                 return this.state == LinkState.End;
+            }
+        }
+
+        /// <summary>
+        /// Fires the <see cref="OnLinkStateProperties"/> event if the flow contains link state properties.
+        /// </summary>
+        /// <param name="flow"></param>
+        protected void MaybeFireOnLinkStateProperties(Flow flow)
+        {
+            Fields linkStateProperties = null;
+            if (flow.Properties != null && flow.Properties.Count > 0)
+            {
+                linkStateProperties = flow.Properties;
+            }
+            if (linkStateProperties != null && this.OnLinkStateProperties != null)
+            {
+                this.OnLinkStateProperties(this, linkStateProperties);
             }
         }
 

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -1,4 +1,4 @@
-﻿//  ------------------------------------------------------------------------------------
+//  ------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation
 //  All rights reserved. 
 //  
@@ -358,6 +358,7 @@ namespace Amqp
 
         internal override void OnFlow(Flow flow)
         {
+           
             lock (this.ThisLock)
             {
                 if (this.drain)
@@ -367,6 +368,9 @@ namespace Amqp
                     this.credit = Math.Min(0, (int)flow.LinkCredit);
                 }
             }
+
+            MaybeFireOnLinkStateProperties(flow);
+
         }
 
         internal override void OnTransfer(Delivery delivery, Transfer transfer, ByteBuffer buffer)

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -1,4 +1,4 @@
-﻿//  ------------------------------------------------------------------------------------
+//  ------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation
 //  All rights reserved. 
 //  
@@ -253,6 +253,7 @@ namespace Amqp
             }
 
             this.WriteDelivery(delivery);
+            MaybeFireOnLinkStateProperties(flow);
         }
 
         internal override void OnTransfer(Delivery delivery, Transfer transfer, ByteBuffer buffer)

--- a/test/Common/ProtocolTests.cs
+++ b/test/Common/ProtocolTests.cs
@@ -300,6 +300,53 @@ namespace Test.Amqp
         }
 
         [TestMethod]
+        public void FlowLinkStatePropertiesCallbackTest()
+        {
+            string testName = "FlowLinkStatePropertiesCallbackTest";
+            ManualResetEvent received = new ManualResetEvent(false);
+            ILink observedLink = null;
+            Fields observedProps = null;
+
+            this.testListener.RegisterTarget(TestPoint.Attach, (stream, channel, fields) =>
+            {
+                return TestOutcome.Stop;
+            });
+
+            this.testListener.RegisterTarget(TestPoint.Flow, (stream, channel, fields) =>
+            {
+                TestListener.FRM(stream, 0x12UL, 0, channel, testName, 0u, false, null, null, new Source(), new Target());
+                var linkProps = new Fields();
+                linkProps[new Symbol("x-test-link-state")] = true;
+                TestListener.FRM(stream, 0x13UL, 0, channel,
+                    0u, this.testListener.WindowSize, 0u, this.testListener.WindowSize,
+                    fields[4], fields[5], fields[6],
+                    0u, false, false,
+                    linkProps);
+                return TestOutcome.Stop;
+            });
+
+            Open open = new Open() { ContainerId = testName, HostName = "localhost", MaxFrameSize = 2048 };
+            Connection connection = new Connection(this.address, null, open, null);
+            Session session = new Session(connection);
+            ReceiverLink receiver = new ReceiverLink(session, testName, "foo");
+            receiver.OnLinkStateProperties = (link, props) =>
+            {
+                observedLink = link;
+                observedProps = props;
+                received.Set();
+            };
+
+            receiver.SetCredit(100);
+            Assert.IsTrue(received.WaitOne(3000), "OnLinkStateProperties not invoked");
+            connection.Close();
+
+            Assert.IsTrue(object.ReferenceEquals(receiver, observedLink));
+            Assert.IsTrue(observedProps != null);
+            Assert.IsTrue(observedProps.Count > 0);
+            Assert.IsTrue((bool)observedProps[new Symbol("x-test-link-state")]);
+        }
+
+        [TestMethod]
         public void RemoteLinkHandleTest()
         {
             this.testListener.RegisterTarget(TestPoint.Begin, (stream, channel, fields) =>


### PR DESCRIPTION
Invoke an optional ILink.OnLinkStateProperties delegate when a peer sends a non-empty properties map on a flow performative (AMQP 1.0 link state), e.g. for RabbitMQ single-active-consumer notifications. 

Wired from ReceiverLink and SenderLink OnFlow; documented I/O-thread semantics. Add FlowLinkStatePropertiesCallbackTest.

More Informations
===

- This client is the underlying client for [RabbitMQ AMQP 1.0 client](https://github.com/rabbitmq-pro/rabbitmq-amqp-dotnet-client) 

- We need this change to take advantage of https://github.com/rabbitmq/rabbitmq-server/pull/15736, which implements consumer state change notification: if a queue is configured to allow only a single active consumer, consumers receive information about whether they are the active one. We include this information in the FLOW frame only when the consumer attaches, and later if the state changes, so the vast majority of frames won't have this information.

How to test with RabbitMQ
===
When RabbitMQ 4.3 is released, here is an easy way to test it:

Given a Quorum queue called: "qqs" with Single-Active-Consumer enabled:

 
<img width="589" height="144" alt="Screenshot 2026-04-07 at 14 32 05" src="https://github.com/user-attachments/assets/fcf581fa-0b1f-43fe-9605-1a56d2831772" />


Attach two consumers:

```csharp
using Amqp;
using Amqp.Framing;
using Amqp.Types;


Address address = new Address("amqp://guest:guest@127.0.0.1:5672");
Open open = new Open() { ContainerId = "testName", HostName = "localhost", MaxFrameSize = 2048 };
Connection connection = new Connection(address, null, open, null);
Session session = new Session(connection);

List<ReceiverLink> receiverLinks = new();

for (int i = 0; i < 2; i++)
{
    var attach = new Attach
    {
        SndSettleMode = SenderSettleMode.Unsettled,
        RcvSettleMode = ReceiverSettleMode.First,
        LinkName = $"linkId.ToString(){i}",
        // Role = true,
        Target = new Target()
        {
            Address = "/queues/qqs",
            ExpiryPolicy = new Symbol("SESSION_END"),
            Dynamic = false,
            Durable = 0,
        },
        Source = new Source()
        {
            Address = "/queues/qqs",
            ExpiryPolicy = new Symbol("LINK_DETACH"),
            Timeout = 0,
            Dynamic = false,
            Durable = 0,
        }
    };
    ReceiverLink receiver = new ReceiverLink(session, $"receiver_{i}", attach,
        (link, attach1) => { Console.WriteLine("Link attached: " + link.Name); });
    
    receiverLinks.Add(receiver);

    receiver.OnLinkStateProperties = (link, props) =>
    {
           Console.WriteLine($@"{DateTime.Now},  Link state changed {link.Name}" );
        if (props != null)
        {
            foreach (var prop in props)
            {
                Console.WriteLine("  " + prop.Key + ": " + prop.Value);
            }
        }
    };
    receiver.SetCredit(100);
    
    _ = Task.Run(async () =>
    {
        while (true)
        {
            Message? nativeMessage = await receiver.ReceiveAsync(TimeSpan.FromSeconds(30));
            if (nativeMessage != null)
            {
                Console.WriteLine("Received message: " + nativeMessage.Body);
                receiver.Accept(nativeMessage);
            }
        }
    });
    
    await Task.Delay(TimeSpan.FromSeconds(1));
}

await Task.Delay(TimeSpan.FromSeconds(5));
// here the receiver_1 will be promoted to active 
receiverLinks[0].Close();

Console.WriteLine("Press any key to exit.");
Console.ReadKey();
```

output is:

```shell
Link attached: receiver_0
07/04/2026 14:40:34,  Link state changed receiver_0
  rabbitmq:active: True
Link attached: receiver_1
07/04/2026 14:40:35,  Link state changed receiver_1
  rabbitmq:active: False
Press any key to exit.
07/04/2026 14:40:41,  Link state changed receiver_1
  rabbitmq:active: True
```





