### PR TITLE
Handle ObjectDisposedException in WebSocket close

### DIFF
--- a/src/Net/WebSocketTransport.cs
+++ b/src/Net/WebSocketTransport.cs
@@ -111,15 +111,19 @@ namespace Amqp
 
         void ITransport.Close()
         {
-            this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "close", CancellationToken.None)
-                .ContinueWith((t, o) =>
-                {
-                    if (t.IsFaulted)
+            try
+            {
+                this.webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "close", CancellationToken.None)
+                    .ContinueWith((t, o) =>
                     {
-                        var ignored = t.Exception; // prevent unobserved task exception
-                        ((WebSocket)o).Dispose();
-                    }
-                }, this.webSocket);
+                        if (t.IsFaulted)
+                        {
+                            var ignored = t.Exception; // prevent unobserved task exception
+                            ((WebSocket)o).Dispose();
+                        }
+                    }, this.webSocket);
+            }
+            catch (ObjectDisposedException) { }
         }
 
         void ITransport.Send(ByteBuffer buffer)


### PR DESCRIPTION
Wrap `CloseAsync` in a `try/catch (ObjectDisposedException)` to handle the case where the socket is already disposed when `ITransport.Close()` is called

Fixes issue #633 