### PR TITLE
Add DeliveryStateChanged event to SenderLink and ReceiverLink

### DIFF
--- a/src/Handler/Event.cs
+++ b/src/Handler/Event.cs
@@ -111,6 +111,10 @@ namespace Amqp.Handler
         /// </summary>
         ConnectionAccept,
 #endif
+        /// <summary>
+        /// DeliveryStateChanged represents the state changed for a delivery 
+        /// </summary>
+        DeliveryStateChanged
     }
 
     /// <summary>

--- a/src/Handler/IDelivery.cs
+++ b/src/Handler/IDelivery.cs
@@ -50,5 +50,10 @@ namespace Amqp.Handler
         /// Gets or sets the Settled field.
         /// </summary>
         bool Settled { get; set; }
+        
+        /// <summary>
+        /// Get the Message
+        /// </summary>
+        Message Message { get; }
     }
 }

--- a/src/ReceiverLink.cs
+++ b/src/ReceiverLink.cs
@@ -455,6 +455,12 @@ namespace Amqp
 
         internal override void OnDeliveryStateChanged(Delivery delivery)
         {
+            IHandler handler = this.Session.Connection.Handler;
+            if (handler != null && handler.CanHandle(EventId.DeliveryStateChanged))
+            {
+                handler.Handle(Event.Create(EventId.DeliveryStateChanged, 
+                    this.Session.Connection, this.Session, this, context: delivery));
+            }
         }
 
         /// <summary>

--- a/src/SenderLink.cs
+++ b/src/SenderLink.cs
@@ -166,7 +166,8 @@ namespace Amqp
 #endif
         }
 
-        void SendInternal(Message message, DeliveryState deliveryState, OutcomeCallback callback, object state, bool sync)
+        void SendInternal(Message message, DeliveryState deliveryState, OutcomeCallback callback, object state,
+            bool sync)
         {
             const int reservedBytes = 40;
 #if NETFX || NETFX40 || DOTNET
@@ -195,7 +196,8 @@ namespace Amqp
             IHandler handler = this.Session.Connection.Handler;
             if (handler != null && handler.CanHandle(EventId.SendDelivery))
             {
-                handler.Handle(Event.Create(EventId.SendDelivery, this.Session.Connection, this.Session, this, context: delivery));
+                handler.Handle(Event.Create(EventId.SendDelivery, this.Session.Connection, this.Session, this,
+                    context: delivery));
             }
 
             lock (this.ThisLock)
@@ -279,6 +281,13 @@ namespace Amqp
                 }
 #endif
                 delivery.OnOutcome(this, delivery.Message, outcome, delivery.UserToken);
+            }
+
+            IHandler handler = this.Session.Connection.Handler;
+            if (handler != null && handler.CanHandle(EventId.DeliveryStateChanged))
+            {
+                handler.Handle(Event.Create(EventId.DeliveryStateChanged, this.Session.Connection, this.Session, this,
+                    context: delivery));
             }
         }
 

--- a/test/Common/ProtocolTests.cs
+++ b/test/Common/ProtocolTests.cs
@@ -2099,7 +2099,7 @@ namespace Test.Amqp
 
             Action<Dictionary<EventId, int>> validator = dict =>
             {
-                Assert.AreEqual(11, dict.Count);
+                Assert.AreEqual(12, dict.Count);
                 Assert.AreEqual(1, dict[EventId.SocketConnect]);
                 Assert.AreEqual(1, dict[EventId.ConnectionLocalOpen]);
                 Assert.AreEqual(1, dict[EventId.ConnectionRemoteOpen]);

--- a/test/Common/ProtocolTests.cs
+++ b/test/Common/ProtocolTests.cs
@@ -2113,6 +2113,7 @@ namespace Test.Amqp
                 Assert.AreEqual(1, dict[EventId.ReceiveDelivery]);
                 Assert.AreEqual(1, dict[EventId.ConnectionLocalClose]);
                 Assert.AreEqual(1, dict[EventId.ConnectionRemoteClose]);
+                Assert.AreEqual(1, dict[EventId.DeliveryStateChanged]);
             };
 
             Trace.WriteLine(TraceLevel.Information, "sync test");


### PR DESCRIPTION
Introduce a new EventId.DeliveryStateChanged to the Event enum and fire it from both SenderLink.OnOutcome and ReceiverLink.OnDeliveryStateChanged when a delivery state changes. Add a Message property to the IDelivery interface to expose the associated message to handlers.

Closes https://github.com/Azure/amqpnetlite/issues/637